### PR TITLE
ci: add secret scan to pr pipeline

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Go 1.19
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Go 1.19
@@ -61,7 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(fromJSON('["pull_request"]'), github.event_name)
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v5
@@ -76,6 +77,24 @@ jobs:
         with:
           fetch-depth: 0
       - uses: apache/skywalking-eyes@main
+
+  # The TruffleHog OSS Github Action can be used to scan a range of commits for leaked credentials. The action will fail if any results are found.
+  # More see: https://github.com/marketplace/actions/trufflehog-oss
+  SecretScan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --json
 
   # TODO: Uncomment when the repository is publicly.
   # DependencyReview:


### PR DESCRIPTION
## What type of PR is this?
/kind chore

## What this PR does / why we need it:
* Add secret scan to pr pipeline, the scan tool use `trufflehog`
* The TruffleHog Github Action can be used to scan a range of commits for leaked credentials. The action will fail if any results are found.

Screenshot:

![image](https://user-images.githubusercontent.com/9360247/235087038-1400f0f1-0fed-485f-999e-64d9c7fbacaa.png)
