### PR TITLE
chore: turn off the comment switch in .licenserc.yaml

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -66,5 +66,5 @@ header:
     - 'LICENSE'
     - 'OWNERS_ALIASES'
     - 'SECURITY_CONTACTS'
-  comment: on-failure
+  comment: never
   license-location-threshold: 80


### PR DESCRIPTION
## What type of PR is this?
/kind chore

## What this PR does / why we need it:
Turn off the comment switch in .licenserc.yaml