### PR TITLE
feat: support sanitize kubeconfig in cluster manager

### DIFF
--- a/pkg/core/manager/cluster/manager_test.go
+++ b/pkg/core/manager/cluster/manager_test.go
@@ -1,0 +1,90 @@
+// Copyright The Karbour Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestClusterManager_SanitizeKubeConfigWithYAML(t *testing.T) {
+	// Create a mock context with a logger (use your actual logger initialization)
+	ctx := context.Background()
+
+	// Create a fake KubeConfig in YAML format with sensitive data
+	fakeYAML := `
+apiVersion: v1
+kind: Config
+users:
+- name: test-user
+  user:
+    client-certificate-data: sensitive-cert-data
+    client-key-data: sensitive-key-data
+    token: sensitive-token
+    username: sensitive-username
+    password: sensitive-password
+clusters:
+- name: test-cluster
+  cluster:
+    certificate-authority-data: sensitive-ca-data
+`
+	t.Log("Plain YAML output:")
+	t.Log(fakeYAML)
+
+	// Initialize ClusterManager
+	cm := NewClusterManager(&Config{})
+
+	// Call SanitizeKubeConfigWithYAML method with the fake data
+	sanitizedYAML, err := cm.SanitizeKubeConfigWithYAML(ctx, fakeYAML)
+	if err != nil {
+		t.Fatalf("SanitizeKubeConfigWithYAML returned an unexpected error: %v", err)
+	}
+
+	// Verify that the sanitized YAML string does not contain any of the sensitive data
+	var sanitizedConfig KubeConfig
+	err = yaml.Unmarshal([]byte(sanitizedYAML), &sanitizedConfig)
+	if err != nil {
+		t.Fatalf("Error unmarshaling sanitized YAML: %v", err)
+	}
+	t.Log("Sanitized YAML output:")
+	t.Log(sanitizedYAML)
+
+	// Check if the sensitive data has been masked properly
+	for _, user := range sanitizedConfig.Users {
+		if containsSensitiveData(user.User.ClientCertificateData) ||
+			containsSensitiveData(user.User.ClientKeyData) ||
+			containsSensitiveData(user.User.Token) ||
+			containsSensitiveData(user.User.Username) ||
+			containsSensitiveData(user.User.Password) {
+			t.Errorf("Sensitive data was not properly masked")
+		}
+	}
+	for _, cluster := range sanitizedConfig.Clusters {
+		if containsSensitiveData(cluster.Cluster.CertificateAuthorityData) {
+			t.Errorf("Sensitive data was not properly masked")
+		}
+	}
+}
+
+// containsSensitiveData is a helper function to check if the given data is masked properly.
+// In a real test, you would check if the data is masked according to the maskContent logic.
+func containsSensitiveData(data string) bool {
+	// This is where you check if the data is in masked format (e.g., does not contain sensitive values)
+	// This is a placeholder function and should be replaced with actual logic to verify masked content.
+	return strings.Contains(data, "sensitive")
+}

--- a/pkg/core/manager/cluster/types.go
+++ b/pkg/core/manager/cluster/types.go
@@ -31,3 +31,52 @@ type ClusterDetail struct {
 	CPUCapacity    int64
 	PodsCapacity   int64
 }
+
+// KubeConfig represents the structure of a kubeconfig file
+type KubeConfig struct {
+	APIVersion     string         `yaml:"apiVersion"`
+	Kind           string         `yaml:"kind"`
+	Clusters       []ClusterEntry `yaml:"clusters"`
+	Contexts       []ContextEntry `yaml:"contexts"`
+	CurrentContext string         `yaml:"current-context"`
+	Users          []UserEntry    `yaml:"users"`
+}
+
+// ClusterEntry represents each cluster entry in kubeconfig
+type ClusterEntry struct {
+	Name    string  `yaml:"name"`
+	Cluster Cluster `yaml:"cluster"`
+}
+
+// Cluster contains the cluster information
+type Cluster struct {
+	Server                   string `yaml:"server"`
+	CertificateAuthorityData string `yaml:"certificate-authority-data,omitempty"`
+}
+
+// ContextEntry represents each context entry in kubeconfig
+type ContextEntry struct {
+	Name    string  `yaml:"name"`
+	Context Context `yaml:"context"`
+}
+
+// Context contains the context information
+type Context struct {
+	Cluster string `yaml:"cluster"`
+	User    string `yaml:"user"`
+}
+
+// UserEntry represents each user entry in kubeconfig
+type UserEntry struct {
+	Name string `yaml:"name"`
+	User User   `yaml:"user"`
+}
+
+// User contains the user information
+type User struct {
+	ClientCertificateData string `yaml:"client-certificate-data,omitempty"`
+	ClientKeyData         string `yaml:"client-key-data,omitempty"`
+	Token                 string `yaml:"token,omitempty"`
+	Username              string `yaml:"username,omitempty"`
+	Password              string `yaml:"password,omitempty"`
+}

--- a/pkg/core/manager/cluster/util.go
+++ b/pkg/core/manager/cluster/util.go
@@ -1,0 +1,35 @@
+// Copyright The Karbour Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"crypto/md5"
+	"fmt"
+	"strings"
+)
+
+// maskContent to apply MD5 hash and mask the content.
+func maskContent(content string) string {
+	// Apply MD5 hash
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(content)))
+
+	// Calculate the range for masking
+	maskLength := len(hash) * 3 / 4 // Three quarters of the hash length
+	start := len(hash) / 8          // Start masking a quarter in
+	end := start + maskLength       // End masking
+	masked := hash[:start] + strings.Repeat("*", maskLength) + hash[end:]
+
+	return masked
+}


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it:
Support sanitize specified `KubeConfig` by `ClusterManager`.

Screenshots:
![image](https://github.com/KusionStack/karbour/assets/9360247/4db6da62-bed0-4b19-a3c8-1da59b2bf701)
