### PR TITLE
feat: support construction of cluster certificates for service accoun…

### DIFF
--- a/pkg/syncer/reconciler.go
+++ b/pkg/syncer/reconciler.go
@@ -335,7 +335,7 @@ func buildClusterConfig(cluster *clusterv1beta1.Cluster) (*rest.Config, error) {
 	if access.Credential != nil {
 		switch access.Credential.Type {
 		case clusterv1beta1.CredentialTypeServiceAccountToken:
-			// TODO: CredentialTypeServiceAccountToken
+			config.BearerToken = access.Credential.ServiceAccountToken
 		case clusterv1beta1.CredentialTypeX509Certificate:
 			if access.Credential.X509 == nil {
 				return nil, fmt.Errorf("cert and key is required for x509 credential type")


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it:
The current resource syncer does not support synchronization of resources in clusters with service account types. This PR adds support for this scenario.
