### PR TITLE
fix: fixed an issue where credential can be leaked from k8s apis

### DIFF
--- a/pkg/apis/cluster/types.go
+++ b/pkg/apis/cluster/types.go
@@ -44,48 +44,51 @@ type Cluster struct {
 
 // ClusterList is a list of Cluster objects.
 type ClusterList struct {
-	metav1.TypeMeta
-	metav1.ListMeta
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 
-	Items []Cluster
+	Items []Cluster `json:"items"`
 }
 
 type ClusterSpec struct {
-	Provider    string
-	Description string
-	DisplayName string
-	Access      ClusterAccess
-	Finalized   *bool
+	Provider string        `json:"provider"`
+	Access   ClusterAccess `json:"access"`
+	// +optional
+	Description string `json:"description,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Finalized   *bool  `json:"finalized,omitempty"`
 }
 
 type ClusterStatus struct {
-	Healthy bool
+	Healthy bool `json:"healthy,omitempty"`
 }
 
 type ClusterAccess struct {
-	Endpoint   string
-	CABundle   []byte
-	Insecure   *bool
-	Credential *ClusterAccessCredential
+	Endpoint string `json:"endpoint"`
+	// +optional
+	CABundle   []byte                   `json:"caBundle,omitempty"`
+	Insecure   *bool                    `json:"insecure,omitempty"`
+	Credential *ClusterAccessCredential `json:"credential,omitempty"`
 }
 
 type ClusterAccessCredential struct {
-	Type                CredentialType
-	ServiceAccountToken string
-	X509                *X509
+	Type CredentialType `json:"type"`
+	// +optional
+	ServiceAccountToken string `json:"serviceAccountToken,omitempty"`
+	X509                *X509  `json:"x509,omitempty"`
 }
 
 type X509 struct {
-	Certificate []byte
-	PrivateKey  []byte
+	Certificate []byte `json:"certificate"`
+	PrivateKey  []byte `json:"privateKey"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type ClusterProxyOptions struct {
-	metav1.TypeMeta
+	metav1.TypeMeta `json:",inline"`
 
 	// Path is the target api path of the proxy request.
 	// e.g. "/healthz", "/api/v1"
-	Path string
+	Path string `json:"path,omitempty"`
 }

--- a/pkg/apis/cluster/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/cluster/v1beta1/zz_generated.conversion.go
@@ -209,17 +209,7 @@ func Convert_cluster_ClusterAccessCredential_To_v1beta1_ClusterAccessCredential(
 
 func autoConvert_v1beta1_ClusterList_To_cluster_ClusterList(in *ClusterList, out *cluster.ClusterList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]cluster.Cluster, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_Cluster_To_cluster_Cluster(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]cluster.Cluster)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -230,17 +220,7 @@ func Convert_v1beta1_ClusterList_To_cluster_ClusterList(in *ClusterList, out *cl
 
 func autoConvert_cluster_ClusterList_To_v1beta1_ClusterList(in *cluster.ClusterList, out *ClusterList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]Cluster, len(*in))
-		for i := range *in {
-			if err := Convert_cluster_Cluster_To_v1beta1_Cluster(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]Cluster)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -305,11 +285,11 @@ func Convert_v1beta1_ClusterSpec_To_cluster_ClusterSpec(in *ClusterSpec, out *cl
 
 func autoConvert_cluster_ClusterSpec_To_v1beta1_ClusterSpec(in *cluster.ClusterSpec, out *ClusterSpec, s conversion.Scope) error {
 	out.Provider = in.Provider
-	out.Description = in.Description
-	out.DisplayName = in.DisplayName
 	if err := Convert_cluster_ClusterAccess_To_v1beta1_ClusterAccess(&in.Access, &out.Access, s); err != nil {
 		return err
 	}
+	out.Description = in.Description
+	out.DisplayName = in.DisplayName
 	out.Finalized = (*bool)(unsafe.Pointer(in.Finalized))
 	return nil
 }

--- a/pkg/registry/cluster/status.go
+++ b/pkg/registry/cluster/status.go
@@ -1,0 +1,81 @@
+/*
+Copyright The Karbour Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+
+	"github.com/KusionStack/karbour/pkg/apis/cluster"
+	clustermgr "github.com/KusionStack/karbour/pkg/core/manager/cluster"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+)
+
+var _ rest.Getter = &StatusREST{}
+
+type StatusREST struct {
+	Store *genericregistry.Store
+}
+
+// New returns empty Cluster object.
+func (r *StatusREST) New() runtime.Object {
+	return &cluster.Cluster{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	sanitized := &unstructured.Unstructured{}
+	cluster, err := r.Store.Get(ctx, name, options)
+	if err != nil {
+		return sanitized, nil
+	}
+	clusterMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cluster)
+	if err != nil {
+		return sanitized, nil
+	}
+	clusterUnstructured := &unstructured.Unstructured{}
+	clusterUnstructured.SetUnstructuredContent(clusterMap)
+	sanitized, _ = clustermgr.SanitizeUnstructuredCluster(ctx, clusterUnstructured)
+	return sanitized, nil
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
+	// subresources should never allow create on update.
+	return r.Store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.Store.GetResetFields()
+}
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.Store.ConvertToTable(ctx, object, tableOptions)
+}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

- Fixed an issue where cluster credential including serviceAccountToken and privateKey can be leaked from k8s list/get apis directly
- Cluster information retrieved should now be correctly masked when using Kubernetes apis to fetch CRs directly
