### PR TITLE
fix: unordered endpoints

### DIFF
--- a/pkg/core/server/server.go
+++ b/pkg/core/server/server.go
@@ -17,6 +17,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	docs "github.com/KusionStack/karbour/api/openapispec"
@@ -34,7 +35,6 @@ import (
 	"github.com/KusionStack/karbour/pkg/registry"
 	"github.com/KusionStack/karbour/pkg/registry/search"
 	"github.com/KusionStack/karbour/pkg/search/storage"
-
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	httpswagger "github.com/swaggo/http-swagger"
@@ -74,9 +74,7 @@ func NewCoreServer(
 
 	// Set up the root routes.
 	docs.SwaggerInfo.BasePath = "/"
-	router.Route("/", func(r chi.Router) {
-		r.Get("/docs/*", httpswagger.Handler())
-	})
+	router.Get("/docs/*", httpswagger.Handler())
 
 	// Set up the API routes for version 1 of the API.
 	router.Route("/api/v1", func(r chi.Router) {
@@ -150,12 +148,13 @@ func setupAPIV1(
 func listEndpoints(r chi.Router) []string {
 	var endpoints []string
 	walkFunc := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
-		endpoint := fmt.Sprintf("%s %s", method, route)
+		endpoint := fmt.Sprintf("%s\t%s", method, route)
 		endpoints = append(endpoints, endpoint)
 		return nil
 	}
 	if err := chi.Walk(r, walkFunc); err != nil {
 		fmt.Printf("Walking routes error: %s\n", err.Error())
 	}
+	sort.Strings(endpoints)
 	return endpoints
 }


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Fix unordered endpoints (The result returned by each call `/endpoints` is unordered)

![image](https://github.com/KusionStack/karbour/assets/9360247/ce87ab07-57a4-4527-90f0-b1afb9f0c316)
