### PR TITLE
chore: remove unit test temporarily

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,30 +9,31 @@ on:
     branches:
     - main
 jobs:
-  Test:
-    name: Unit Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.19
+  # TODO: Remove the unit test temporarily, because it is almost over the free limit of Github Action
+  # Test:
+  #   name: Unit Test
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Set up Go 1.19
+  #       uses: actions/setup-go@v2
+  #       with:
+  #         go-version: 1.19
 
-      - run: go build ./...
-      - run: go vet ./...
+  #     - run: go build ./...
+  #     - run: go vet ./...
 
-      - name: Running go tests with coverage
-        env:
-          GO111MODULE: on
-        run: make cover
-      # - name: Send coverage
-      #   uses: shogo82148/actions-goveralls@v1
-      #   with:
-      #     path-to-profile: coverage.out
+  #     - name: Running go tests with coverage
+  #       env:
+  #         GO111MODULE: on
+  #       run: make cover
+  #     # - name: Send coverage
+  #     #   uses: shogo82148/actions-goveralls@v1
+  #     #   with:
+  #     #     path-to-profile: coverage.out
 
   GolangLint:
     name: Golang Lint


### PR DESCRIPTION
## What type of PR is this?
/kind chore

## What this PR does / why we need it:
Remove the unit test temporarily, because it is almost over the free limit of Github Action.
