### PR TITLE
fix: cluster displayName and description are now correctly stored

### DIFF
--- a/pkg/core/manager/cluster/manager.go
+++ b/pkg/core/manager/cluster/manager.go
@@ -76,7 +76,7 @@ func (c *ClusterManager) CreateCluster(ctx context.Context, client *multicluster
 	}
 
 	// Convert the rest.Config to Cluster object and create it using dynamic client
-	clusterObj, err := clusterinstall.ConvertKubeconfigToCluster(name, description, displayName, restConfig)
+	clusterObj, err := clusterinstall.ConvertKubeconfigToCluster(name, displayName, description, restConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

- Cluster display name and description are now correctly stored

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
