### PR TITLE
fix: invalid es mapping config

### DIFF
--- a/pkg/infra/search/storage/elasticsearch/index.go
+++ b/pkg/infra/search/storage/elasticsearch/index.go
@@ -28,7 +28,7 @@ const (
 	defaultMapping   = `{
   "settings":{
     "index":{
-      "max_result_window": 1000000",
+      "max_result_window": "1000000",
       "number_of_shards":1,
       "auto_expand_replicas":"0-1",
       "number_of_replicas":0


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Fix invalid `elasticsearch` mapping config.