### PR TITLE
chore: refine cover target in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ test:  ## Run the tests
 
 .PHONY: cover
 cover:  ## Generates coverage report
-	@go test -gcflags=all=-l -timeout=10m `go list $(GOSOURCE_PATHS) | grep -v "internalimport"` -coverprofile $(COVERAGEOUT) ${TEST_FLAGS} && \
-	(echo "\nCalculate coverage rate:"; go tool cover -func=coverage.out) || (echo "💥 Running go test fail!"; exit 1)
+	@echo "🚀 Executing all unit tests:"; go test -gcflags=all=-l -timeout=10m `go list $(GOSOURCE_PATHS) | grep -vE "internalimport|generated"` -coverprofile $(COVERAGEOUT) ${TEST_FLAGS} && \
+	(echo "\n📊 Calculating coverage rate:"; go tool cover -func=$(COVERAGEOUT)) || (echo "\n💥 Running go test fail!"; exit 1)
 
 # Target: update-codegen
 # Description: Updates the generated code using the 'hack/update-codegen.sh' script.


### PR DESCRIPTION
## What type of PR is this?
/kind chore

## What this PR does / why we need it:

- Pretty the output of `make cover`
- Add `generated` to ignore paths in `cover` target 

