### PR TITLE
fix: lint problems

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ Add one of the following kinds:
 /kind chore
 /kind perf
 /kind style
+/kind test
 -->
 
 ## What this PR does / why we need it:
@@ -17,9 +18,11 @@ Add one of the following kinds:
 TODO
 
 ## Which issue(s) this PR fixes:
+
 <!--
 *Automatically closes linked issue when PR is merged.
 Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
 _If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
 -->
+
 Fixes #

--- a/pkg/core/manager/cluster/manager_test.go
+++ b/pkg/core/manager/cluster/manager_test.go
@@ -75,7 +75,6 @@ func TestGetCluster(t *testing.T) {
 
 				realSensitiveValue = getByteSliceFieldValue(cluster, "spec", "access", "credential", "x509", "privateKey")
 				require.Contains(t, realSensitiveValue, "***", "Expected the spec.access.credential.x509.privateKey to be sanitized.")
-
 			}
 		})
 	}

--- a/pkg/util/sql2es/convert.go
+++ b/pkg/util/sql2es/convert.go
@@ -707,9 +707,9 @@ func extractFuncAndColFromSelect(sqlSelect sqlparser.SelectExprs) ([]*sqlparser.
 			continue
 		}
 
-		switch expr.Expr.(type) {
+		switch exprExpr := expr.Expr.(type) {
 		case *sqlparser.FuncExpr:
-			funcExpr := expr.Expr.(*sqlparser.FuncExpr)
+			funcExpr := exprExpr
 			funcArr = append(funcArr, funcExpr)
 		case *sqlparser.ColName:
 			continue


### PR DESCRIPTION
## What type of PR is this?
/kind refactor

## What this PR does / why we need it:
Fix 2 lint problems according to the following scanning results with `golangci-lint`:

![image](https://github.com/KusionStack/karbour/assets/9360247/79fbea21-7eb6-4664-bb10-bf7461962daa)

