### PR TITLE
fix: support create defult resource group rule if not exists

### DIFF
--- a/pkg/infra/persistence/elasticsearch/client.go
+++ b/pkg/infra/persistence/elasticsearch/client.go
@@ -312,6 +312,23 @@ func (cl *Client) AggregateDocumentByTerms(ctx context.Context, index string, fi
 	return cl.multiTermsAgg(ctx, index, fields)
 }
 
+// Refresh refresh specified index in Elasticsearch.
+func (cl *Client) Refresh(
+	ctx context.Context,
+	indexName string,
+) error {
+	opts := []func(*esapi.IndicesRefreshRequest){
+		cl.client.Indices.Refresh.WithContext(ctx),
+		cl.client.Indices.Refresh.WithIndex(indexName),
+	}
+
+	_, err := cl.client.Indices.Refresh(opts...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // multiTermsAggSearch executes a multi-term aggregation query on specified fields.
 func (cl *Client) multiTermsAgg(ctx context.Context, index string, fields []string) (*AggResults, error) {
 	// Construct the terms for multi-term aggregation based on the fields.

--- a/pkg/infra/search/storage/elasticsearch/client.go
+++ b/pkg/infra/search/storage/elasticsearch/client.go
@@ -84,6 +84,10 @@ func NewStorage(cfg esv8.Config) (*Storage, error) {
 
 // createResourceGroupRuleIfNotExists checks if a resource group rule exists and creates it if it does not.
 func createResourceGroupRuleIfNotExists(cl *elasticsearch.Client, ruleName string) error {
+	if err := cl.Refresh(context.Background(), defaultResourceGroupRuleIndexName); err != nil {
+		return err
+	}
+
 	query := make(map[string]interface{})
 	query["query"] = esquery.Bool().Must(
 		esquery.Term(resourceKeyName, ruleName),


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Support create defult resource group rule if not exists


## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #
