### PR TITLE
fix: missing boilerplate.go.txt and custom-boilerplate.go.txt files in hack

### DIFF
--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright The Karpor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/hack/custom-boilerplate.go.txt
+++ b/hack/custom-boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright The Karpor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:

Fix missing boilerplate.go.txt and custom-boilerplate.go.txt files in hack

