### PR TITLE
fix(ui): wrong public config in package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,6 @@
   "name": "Karpor-dashboard",
   "version": "0.2.0",
   "private": true,
-  "homepage": "/public/",
   "dependencies": {
     "@ant-design/icons": "^5.2.6",
     "@antv/g2": "^5.1.13",
@@ -58,7 +57,7 @@
   "scripts": {
     "release": "standard-version",
     "start": "GENERATE_SOURCEMAP=false HTTPS=true craco start",
-    "build": "GENERATE_SOURCEMAP=false craco build",
+    "build": "GENERATE_SOURCEMAP=false PUBLIC_URL=/public/ craco build",
     "lint:prettier": "prettier --write src\"/**/*.+(js|ts|tsx|jsx|json|md|json)\"",
     "lint:style": "stylelint src\"/**/*.+(css|scss|less|stylus|sass|postcss)\" --fix",
     "lint:fix": "eslint --fix --ext .js,.jsx,.ts,.tsx src",


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fix wrong public config in package.json. The current package.json config will open the wrong link `127.0.0.1:3000/public` by default after `npm run start` is executed.

