### PR TITLE
fix: missing replace for hack/cert-generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -173,3 +173,5 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.35 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 )
+
+replace github.com/KusionStack/karpor/hack/cert-generator => ./hack/cert-generator


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:

Fix missing replace for hack/cert-generator. Otherwise, an error will be reported:
```bash
go: github.com/KusionStack/karpor/hack/cert-generator@v0.3.23-alpha.2: module github.com/KusionStack/karpor@v0.3.23-alpha.2 found, but does not contain package github.c
om/KusionStack/karpor/hack/cert-generator
```

