### PR TITLE
fix(build): missing ui/build/.gitkeep for correct build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ __debug_bin
 
 # build
 dist/
-build/
 ui/build/*
 !ui/build/.gitkeep
 _build/


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fix missing ui/build/.gitkeep for correct build:

![image](https://github.com/KusionStack/karpor/assets/9360247/ba83b4d6-46ec-44bf-bb10-6def8d3e3e1b)


