### PR TITLE
feat: add --github-badge flag to core options

### DIFF
--- a/cmd/app/options/core_options.go
+++ b/cmd/app/options/core_options.go
@@ -21,6 +21,7 @@ import (
 
 type CoreOptions struct {
 	ReadOnlyMode bool
+	GithubBadge  bool
 }
 
 func NewCoreOptions() *CoreOptions {
@@ -33,6 +34,7 @@ func (o *CoreOptions) Validate() []error {
 
 func (o *CoreOptions) ApplyTo(config *registry.ExtraConfig) error {
 	config.ReadOnlyMode = o.ReadOnlyMode
+	config.GithubBadge = o.GithubBadge
 	return nil
 }
 
@@ -43,4 +45,5 @@ func (o *CoreOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	fs.BoolVar(&o.ReadOnlyMode, "read-only-mode", false, "turn on the read only mode")
+	fs.BoolVar(&o.GithubBadge, "github-badge", false, "whether to display the github badge")
 }

--- a/pkg/kubernetes/registry/types.go
+++ b/pkg/kubernetes/registry/types.go
@@ -36,4 +36,5 @@ type ExtraConfig struct {
 	ElasticSearchUsername  string
 	ElasticSearchPassword  string
 	ReadOnlyMode           bool
+	GithubBadge            bool
 }


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it:

Add `--github-badge` flag to core options.

![image](https://github.com/KusionStack/karpor/assets/9360247/b65be263-fa64-47f8-9822-d39b1da5471d)


## Which issue(s) this PR fixes:

Prepare for #501 
