### PR TITLE
fix: missing insight authorize in default rbac config

### DIFF
--- a/config/default-rbac.yaml
+++ b/config/default-rbac.yaml
@@ -19,6 +19,8 @@ rules:
       - /server-configs
       - /search
       - /search/*
+      - /insight
+      - /insight/*
       - /insightDetail
       - /insightDetail/*
       - /cluster


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fix missing insight authorize in default rbac config. Nice catch @ruquanzhao !

