### PR TITLE
fix(ui): wrong topology resources list when switch cluster

### DIFF
--- a/ui/src/pages/insightDetail/group/index.tsx
+++ b/ui/src/pages/insightDetail/group/index.tsx
@@ -76,7 +76,7 @@ const ClusterDetail = () => {
           const kindTmp = item?.id?.split('.')
           const len = kindTmp?.length
           const lastKindTmp = kindTmp?.[len - 1]
-          if (lastKindTmp === 'Pod') {
+          if (lastKindTmp === (tableName || 'Pod')) {
             return true
           } else {
             return false


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:

Fix wrong topology resources list when switching cluster. 
