### PR TITLE
fix: Add support to manage token based auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 .PHONY: test
 test:  ## Run the tests
 	@PKG_LIST=$${TARGET_PKG:-$(GOSOURCE_PATHS)}; \
-	go test -gcflags=all=-l -timeout=10m `go list $${PKG_LIST} | grep -vE "internalimport|generated|handler"` ${TEST_FLAGS}
+	go test -gcflags=all=-l -timeout=10m `go list -e $${PKG_LIST} | grep -vE "internalimport|generated|handler"` ${TEST_FLAGS}
 
 
 # cover: Generates a coverage report for the specified TARGET_PKG or default GOSOURCE_PATHS.

--- a/pkg/core/handler/cluster/cluster.go
+++ b/pkg/core/handler/cluster/cluster.go
@@ -365,6 +365,7 @@ func ValidateKubeConfig(clusterMgr *cluster.ClusterManager) http.HandlerFunc {
 		// Decode the request body into the payload.
 		payload := &ValidatePayload{}
 		if err := payload.Decode(r); err != nil {
+			log.Error(err, "failed to decode kubeconfig")
 			render.Render(w, r, handler.FailureResponse(ctx, err))
 			return
 		}
@@ -378,6 +379,8 @@ func ValidateKubeConfig(clusterMgr *cluster.ClusterManager) http.HandlerFunc {
 		if info, err := clusterMgr.ValidateKubeConfigWithYAML(ctx, payload.KubeConfig); err == nil {
 			render.JSON(w, r, handler.SuccessResponse(ctx, info))
 		} else {
+			log.Error(err, "failed to validate kubeconfig")
+			w.WriteHeader(http.StatusBadRequest)
 			render.Render(w, r, handler.FailureResponse(ctx, err))
 		}
 	}

--- a/pkg/core/manager/cluster/types.go
+++ b/pkg/core/manager/cluster/types.go
@@ -23,6 +23,7 @@ var (
 	ErrMissingUserEntry            = errors.New("at least one user entry is required")
 	ErrMissingClusterName          = errors.New("cluster name is required")
 	ErrMissingClusterServer        = errors.New("cluster server is required")
+	ErrBothInsecureAndCertificateAuthority = errors.New("certificate-authority-data and insecure-skip-tls-verify couldn't both be set")
 	ErrMissingCertificateAuthority = errors.New("certificate-authority-data is required")
 	ErrInvalidCertificateAuthority = errors.New("certificate-authority-data is invalid")
 	ErrClusterServerConnectivity   = errors.New("cannot connect to the cluster server")
@@ -70,6 +71,7 @@ type ClusterEntry struct {
 //
 //nolint:tagliatelle
 type Cluster struct {
+	Insecure bool 					`yaml:"insecure-skip-tls-verify,omitempty"`
 	Server                   string `yaml:"server"`
 	CertificateAuthorityData string `yaml:"certificate-authority-data,omitempty"`
 }


### PR DESCRIPTION
## What type of PR is this?

/kind refactor

## What this PR does / why we need it:

If uploading a token based kubeconfig, error reported as invalid kubeconfig.

In fact, token based kubeconfig is general usage in many cases.

ref: https://kb.leaseweb.com/products/kubernetes/users-roles-and-permissions-on-kubernetes-rbac/create-a-token-based-kubeconfig
