### PR TITLE
fix(syncer): wrong address operator on transform Patch func

### DIFF
--- a/pkg/syncer/transform/transform.go
+++ b/pkg/syncer/transform/transform.go
@@ -92,7 +92,7 @@ func Patch(original interface{}, patchText string) (interface{}, error) {
 	if err := json.Unmarshal(modifiedJSON, &dest); err != nil {
 		return nil, errors.Wrap(err, "json decoding error")
 	}
-	return &dest, nil
+	return dest, nil
 }
 
 // Replace function replaces the original data structure with the new one derived from the JSON string.


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

The underlying type of `dest` is `*unstructured.Unstructured`, and the address operator makes the return value be a pointer to a pointer, which causes keyFunc `DeletionHandlingMetaNamespaceKeyFunc` to return errors.

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #