### PR TITLE
feat(syncer): supports users to group related resources by adding same label

### DIFF
--- a/pkg/syncer/source.go
+++ b/pkg/syncer/source.go
@@ -259,7 +259,7 @@ func (s *informerSource) parseTransformer() (clientgocache.TransformFunc, error)
 		return nil, fmt.Errorf("unsupported transform type %q", t.Type)
 	}
 
-	tmpl, err := newTemplate(t.ValueTemplate)
+	tmpl, err := newTemplate(t.ValueTemplate, s.cluster)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid transform template")
 	}
@@ -292,6 +292,7 @@ func (s *informerSource) parseTransformer() (clientgocache.TransformFunc, error)
 }
 
 // newTemplate creates and returns a new text template from the provided string, which can be used for processing templates in the syncer.
-func newTemplate(tmpl string) (*template.Template, error) {
-	return template.New("transformTemplate").Funcs(sprig.FuncMap()).Parse(tmpl)
+func newTemplate(tmpl, cluster string) (*template.Template, error) {
+	clusterFuncs, _ := transform.GetClusterTmplFuncs(cluster)
+	return template.New("transformTemplate").Funcs(sprig.FuncMap()).Funcs(clusterFuncs).Parse(tmpl)
 }

--- a/pkg/syncer/transform/tmpl_funcs.go
+++ b/pkg/syncer/transform/tmpl_funcs.go
@@ -1,0 +1,47 @@
+// Copyright The Karpor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"sync"
+	"text/template"
+)
+
+var (
+	clusterTmplFuncs     = make(map[string]template.FuncMap)
+	clusterTmplFuncsLock sync.RWMutex
+)
+
+func RegisterClusterTmplFunc(cluster, FuncName string, tmplFunc any) error {
+	clusterTmplFuncsLock.Lock()
+	defer clusterTmplFuncsLock.Unlock()
+
+	// TODO: check whether the tmplFunc is valid as a template function.
+
+	if _, ok := clusterTmplFuncs[cluster]; !ok {
+		clusterTmplFuncs[cluster] = make(template.FuncMap)
+	}
+
+	clusterTmplFuncs[cluster][FuncName] = tmplFunc
+	return nil
+}
+
+func GetClusterTmplFuncs(cluster string) (template.FuncMap, bool) {
+	clusterTmplFuncsLock.RLock()
+	defer clusterTmplFuncsLock.RUnlock()
+
+	funcs, found := clusterTmplFuncs[cluster]
+	return funcs, found
+}


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it:

For example, we have an app named `ray`, and we want to quick search all its events including deployment and pods.

we can add label `app=ray` to all its events, then we can just type `` where kind = 'Event' and  `labels.app` = "ray" `` to search all related events.

```yaml
---
apiVersion: search.karpor.io/v1beta1
kind: TransformRule
metadata:
  name: for-events
spec:
  type: patch
  valueTemplate: |
    {{- $ref := (objectRef .Object.involvedObject.apiVersion .Object.involvedObject.kind .Object.involvedObject.namespace .Object.involvedObject.name) -}}
    [
      { "op": "add", "path": "/metadata/labels", "value": { "app": "{{ index $ref.Object.metadata.labels "app" }}" } }
    ]
---
apiVersion: search.karpor.io/v1beta1
kind: SyncRegistry
metadata:
  name: events-sync-rule
spec:
  clusters:
    - "*"
  syncResources:
    - apiVersion: v1
      resource: events
      transformRefName: for-events
      namespace: test
```


## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #
