### PR TITLE
fix: wrong link for create token guide

### DIFF
--- a/ui/src/pages/login/index.tsx
+++ b/ui/src/pages/login/index.tsx
@@ -71,7 +71,8 @@ const Login = () => {
                   <p
                     dangerouslySetInnerHTML={{
                       __html: t('TokenCreationGuide', {
-                        linkUrl: 'https://www.kusionstack.io/karpor',
+                        linkUrl:
+                          'https://www.kusionstack.io/karpor/next/user-guide/how-to-create-token',
                       }),
                     }}
                   />


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does / why we need it:

Fix wrong link for create token guide.

## Which issue(s) this PR fixes:

Fixes #520 
