### PR TITLE
fix: wrong endpoint in generated hub cluster config

### DIFF
--- a/pkg/util/certgenerator/generator.go
+++ b/pkg/util/certgenerator/generator.go
@@ -32,7 +32,7 @@ const hubClusterKubeConfigTemplate = `apiVersion: v1
 clusters:
 - cluster:
     insecure-skip-tls-verify: true
-    server: https://127.0.0.1:7443
+    server: karpor-server.%s.svc:7443
   name: karpor
 contexts:
 - context:
@@ -189,5 +189,5 @@ func generateAdminKubeconfig(namespace string, cert *x509.Certificate, key crypt
 	if err != nil {
 		return "", fmt.Errorf("unable to marshal private key to PEM %s", err)
 	}
-	return fmt.Sprintf(hubClusterKubeConfigTemplate, base64.StdEncoding.EncodeToString(certData), base64.StdEncoding.EncodeToString(keyData)), nil
+	return fmt.Sprintf(hubClusterKubeConfigTemplate, namespace, base64.StdEncoding.EncodeToString(certData), base64.StdEncoding.EncodeToString(keyData)), nil
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fix wrong endpoint in generated hub cluster config:

![image](https://github.com/user-attachments/assets/4fd9b90b-fd34-43c0-8043-92ea191bfe9c)

And fix #608 
