### PR TITLE
fix: fix tmpl functions registered but not used

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -235,7 +235,7 @@ func (s *ResourceSyncer) parseTransformer() (clientgocache.TransformFunc, error)
 		return nil, fmt.Errorf("unsupported transform type %q", t.Type)
 	}
 
-	tmpl, err := newTemplate(t.ValueTemplate)
+	tmpl, err := newTemplate(t.ValueTemplate, s.source.Cluster())
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid transform template")
 	}
@@ -283,6 +283,7 @@ func genUnObj(sr v1beta1.ResourceSyncRule, key string) *unstructured.Unstructure
 }
 
 // newTemplate creates and returns a new text template from the provided string, which can be used for processing templates in the syncer.
-func newTemplate(tmpl string) (*template.Template, error) {
-	return template.New("transformTemplate").Funcs(sprig.FuncMap()).Parse(tmpl)
+func newTemplate(tmpl, cluster string) (*template.Template, error) {
+	clusterFuncs, _ := transform.GetClusterTmplFuncs(cluster)
+	return template.New("transformTemplate").Funcs(sprig.FuncMap()).Funcs(clusterFuncs).Parse(tmpl)
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

The cluster template functions has been registered but not used.

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #
