### PR TITLE
feat: soft delete

### DIFF
--- a/pkg/core/entity/resource_group.go
+++ b/pkg/core/entity/resource_group.go
@@ -42,12 +42,12 @@ const (
 
 // ResourceGroup represents information required to locate a resource or multi resources.
 type ResourceGroup struct {
-	Cluster     string            `json:"cluster,omitempty" yaml:"cluster,omitempty"`
-	APIVersion  string            `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
-	Kind        string            `json:"kind,omitempty" yaml:"kind,omitempty"`
-	Namespace   string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Name        string            `json:"name,omitempty" yaml:"name,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Cluster     string            `json:"cluster,omitempty"     yaml:"cluster,omitempty"`
+	APIVersion  string            `json:"apiVersion,omitempty"  yaml:"apiVersion,omitempty"`
+	Kind        string            `json:"kind,omitempty"        yaml:"kind,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"   yaml:"namespace,omitempty"`
+	Name        string            `json:"name,omitempty"        yaml:"name,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"      yaml:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 

--- a/pkg/core/entity/resource_group.go
+++ b/pkg/core/entity/resource_group.go
@@ -89,6 +89,34 @@ func (rg *ResourceGroup) Hash() ResourceGroupHash {
 	return ResourceGroupHash(hash.String())
 }
 
+// ToTerms converts the ResourceGroup to ES query terms.
+func (rg *ResourceGroup) ToTerms() map[string]any {
+	terms := map[string]any{}
+
+	setIfNotEmpty := func(key string, val any) {
+		switch val := val.(type) {
+		case string:
+			if len(val) != 0 {
+				terms[key] = val
+			}
+		case map[string]string:
+			if len(val) != 0 {
+				terms[key] = val
+			}
+		}
+	}
+
+	setIfNotEmpty("cluster", rg.Cluster)
+	setIfNotEmpty("apiVersion", rg.APIVersion)
+	setIfNotEmpty("kind", rg.Kind)
+	setIfNotEmpty("namespace", rg.Namespace)
+	setIfNotEmpty("name", rg.Name)
+	setIfNotEmpty("labels", rg.Labels)
+	setIfNotEmpty("annotations", rg.Annotations)
+
+	return terms
+}
+
 // ToSQL generates a SQL query string based on the ResourceGroup.
 func (rg *ResourceGroup) ToSQL() string {
 	conditions := []string{}

--- a/pkg/core/handler/search/search.go
+++ b/pkg/core/handler/search/search.go
@@ -93,6 +93,8 @@ func SearchForResource(searchMgr *search.SearchManager, searchStorage storage.Se
 			rt.Items = append(rt.Items, search.UniResource{
 				Cluster: res.Cluster,
 				Object:  obj,
+				SyncAt:  res.SyncAt,
+				Deleted: res.Deleted,
 			})
 		}
 		rt.Total = res.Total

--- a/pkg/core/manager/search/types.go
+++ b/pkg/core/manager/search/types.go
@@ -28,6 +28,8 @@ func NewSearchManager() *SearchManager {
 type UniResource struct {
 	Cluster string `json:"cluster"`
 	Object  any    `json:"object"`
+	SyncAt  string `json:"syncAt"`
+	Deleted bool   `json:"deleted"`
 }
 
 type UniResourceList struct {

--- a/pkg/infra/persistence/elasticsearch/client.go
+++ b/pkg/infra/persistence/elasticsearch/client.go
@@ -117,6 +117,27 @@ func (cl *Client) GetDocument(
 	return getResp.Source, nil
 }
 
+// UpdateDocument updates a document with the specified ID
+func (cl *Client) UpdateDocument(
+	ctx context.Context,
+	indexName string,
+	documentID string,
+	body io.Reader,
+) error {
+	resp, err := cl.client.Update(indexName, documentID, body, cl.client.Update.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.IsError() {
+		return &ESError{
+			StatusCode: resp.StatusCode,
+			Message:    resp.String(),
+		}
+	}
+	return nil
+}
+
 // DeleteDocument deletes a document with the specified ID
 func (cl *Client) DeleteDocument(ctx context.Context, indexName string, documentID string) error {
 	if _, err := cl.GetDocument(ctx, indexName, documentID); err != nil {

--- a/pkg/infra/search/storage/elasticsearch/resource.go
+++ b/pkg/infra/search/storage/elasticsearch/resource.go
@@ -56,6 +56,14 @@ func (s *Storage) SaveResource(ctx context.Context, cluster string, obj runtime.
 	return s.client.SaveDocument(ctx, s.resourceIndexName, id, bytes.NewReader(body))
 }
 
+// Refresh will update ES index. If you want the previous document changes to be
+// searchable immediately, you need to call refresh manually.
+//
+// Refer to https://www.elastic.co/guide/en/elasticsearch/guide/current/near-real-time.html to see detail.
+func (s *Storage) Refresh(ctx context.Context) error {
+	return s.client.Refresh(ctx, s.resourceIndexName)
+}
+
 // SoftDeleteResource only sets the deleted field to true, not really deletes the data in storage.
 func (s *Storage) SoftDeleteResource(ctx context.Context, cluster string, obj runtime.Object) error {
 	unObj, ok := obj.(*unstructured.Unstructured)

--- a/pkg/infra/search/storage/elasticsearch/search.go
+++ b/pkg/infra/search/storage/elasticsearch/search.go
@@ -87,7 +87,7 @@ func (s *Storage) searchByDSL(ctx context.Context, dslStr string, pagination *st
 
 // searchBySQL performs a search operation using an SQL string and pagination settings.
 func (s *Storage) searchBySQL(ctx context.Context, sqlStr string, pagination *storage.Pagination) (*storage.SearchResult, error) {
-	dsl, _, err := sql2es.Convert(sqlStr)
+	dsl, _, err := sql2es.ConvertWithDefaultFilter(sqlStr, &sql2es.DeletedFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/infra/search/storage/types.go
+++ b/pkg/infra/search/storage/types.go
@@ -51,6 +51,7 @@ type ResourceStorage interface {
 	DeleteAllResources(ctx context.Context, cluster string) error
 	CountResources(ctx context.Context) (int, error)
 	SoftDeleteResource(ctx context.Context, cluster string, obj runtime.Object) error
+	Refresh(ctx context.Context) error
 }
 
 // ResourceGroupRuleStorage interface defines the basic operations for resource

--- a/pkg/infra/search/storage/types.go
+++ b/pkg/infra/search/storage/types.go
@@ -50,6 +50,7 @@ type ResourceStorage interface {
 	DeleteResource(ctx context.Context, cluster string, obj runtime.Object) error
 	DeleteAllResources(ctx context.Context, cluster string) error
 	CountResources(ctx context.Context) (int, error)
+	SoftDeleteResource(ctx context.Context, cluster string, obj runtime.Object) error
 }
 
 // ResourceGroupRuleStorage interface defines the basic operations for resource
@@ -162,6 +163,8 @@ func (r *SearchResult) ToYAML() (string, error) {
 type Resource struct {
 	entity.ResourceGroup `json:",inline" yaml:",inline"`
 	Object               map[string]interface{} `json:"object"`
+	SyncAt               string                 `json:"syncAt,omitempty"`
+	Deleted              bool                   `json:"deleted,omitempty"`
 }
 
 // NewResource creates a new Resource instance based on the provided bytes
@@ -203,6 +206,14 @@ func Map2Resource(in map[string]interface{}) (*Resource, error) {
 	out.Kind = in["kind"].(string)
 	out.Namespace = in["namespace"].(string)
 	out.Name = in["name"].(string)
+
+	// These two fields are newly added, so they don't exist in the old data.
+	if v, ok := in["syncAt"]; ok {
+		out.SyncAt = v.(string)
+	}
+	if v, ok := in["deleted"]; ok {
+		out.Deleted = v.(bool)
+	}
 
 	content := in["content"].(string)
 	obj := &unstructured.Unstructured{}

--- a/pkg/kubernetes/apis/search/types.go
+++ b/pkg/kubernetes/apis/search/types.go
@@ -111,6 +111,9 @@ type ResourceSyncRule struct {
 
 	// TrimRefName is the name of the TrimRule.
 	TrimRefName string `json:"trimRefName,omitempty"`
+
+	// RemainAfterDeleted indicates whether the resource should remain in ES after being deleted in k8s.
+	RemainAfterDeleted bool
 }
 
 // +genclient

--- a/pkg/kubernetes/apis/search/v1beta1/types.go
+++ b/pkg/kubernetes/apis/search/v1beta1/types.go
@@ -131,6 +131,10 @@ type ResourceSyncRule struct {
 	// TrimRefName is the name of the TrimRule.
 	// +optional
 	TrimRefName string `json:"trimRefName,omitempty"`
+
+	// RemainAfterDeleted indicates whether the resource should remain in ES after being deleted in k8s.
+	// +optional
+	RemainAfterDeleted bool `json:"remainAfterDeleted,omitempty"`
 }
 
 // +genclient

--- a/pkg/kubernetes/apis/search/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubernetes/apis/search/v1beta1/zz_generated.conversion.go
@@ -317,6 +317,7 @@ func autoConvert_v1beta1_ResourceSyncRule_To_search_ResourceSyncRule(in *Resourc
 	out.TransformRefName = in.TransformRefName
 	out.Trim = (*search.TrimRuleSpec)(unsafe.Pointer(in.Trim))
 	out.TrimRefName = in.TrimRefName
+	out.RemainAfterDeleted = in.RemainAfterDeleted
 	return nil
 }
 
@@ -336,6 +337,7 @@ func autoConvert_search_ResourceSyncRule_To_v1beta1_ResourceSyncRule(in *search.
 	out.TransformRefName = in.TransformRefName
 	out.Trim = (*TrimRuleSpec)(unsafe.Pointer(in.Trim))
 	out.TrimRefName = in.TrimRefName
+	out.RemainAfterDeleted = in.RemainAfterDeleted
 	return nil
 }
 

--- a/pkg/kubernetes/generated/openapi/zz_generated.openapi.go
+++ b/pkg/kubernetes/generated/openapi/zz_generated.openapi.go
@@ -729,6 +729,13 @@ func schema_kubernetes_apis_search_v1beta1_ResourceSyncRule(ref common.Reference
 							Format:      "",
 						},
 					},
+					"remainAfterDeleted": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RemainAfterDeleted indicates whether the resource should remain in ES after being deleted in k8s.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"apiVersion", "resource"},
 			},

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/KusionStack/karpor/pkg/infra/search/storage"
 	"github.com/KusionStack/karpor/pkg/infra/search/storage/elasticsearch"
 	"github.com/KusionStack/karpor/pkg/kubernetes/apis/search/v1beta1"
 	"github.com/bytedance/mockey"
@@ -132,7 +133,11 @@ func TestResourceSyncer_Run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewResourceSyncer("cluster1", nil, v1beta1.ResourceSyncRule{APIVersion: "v1", Resource: "services"}, &elasticsearch.Storage{})
 			m := mockey.Mock((*informerSource).HasSynced).Return(true).Build()
+			m2 := mockey.Mock((*elasticsearch.Storage).Refresh).Return(nil).Build()
+			m3 := mockey.Mock((*elasticsearch.Storage).SearchByQuery).Return(&storage.SearchResult{}, nil).Build()
 			defer m.UnPatch()
+			defer m2.UnPatch()
+			defer m3.UnPatch()
 			ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
 			defer cancel()
 			err := s.Run(ctx)

--- a/pkg/syncer/utils/purger.go
+++ b/pkg/syncer/utils/purger.go
@@ -1,0 +1,103 @@
+// Copyright The Karpor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KusionStack/karpor/pkg/infra/search/storage/elasticsearch"
+	"github.com/elliotxx/esquery"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Purger defines the interface for pruning data in storage.
+type Purger interface {
+	Purge(ctx context.Context, syncBefore time.Time) error
+}
+
+var _ Purger = (*ESPurger)(nil)
+
+// NewESPurger creates an ESPurger which implements the Purger interface.
+func NewESPurger(esClient *elasticsearch.Storage, cluster string, gvr schema.GroupVersionResource,
+	store cache.Store, onPurge func(obj client.Object),
+) *ESPurger {
+	return &ESPurger{
+		cluster:  cluster,
+		esClient: esClient,
+		gvr:      gvr,
+		onPurge:  onPurge,
+		store:    store,
+		logger:   ctrl.Log.WithName(fmt.Sprintf("%s-es-purger", gvr.Resource)),
+	}
+}
+
+type ESPurger struct {
+	cluster  string
+	esClient *elasticsearch.Storage
+	gvr      schema.GroupVersionResource
+	onPurge  func(obj client.Object)
+	store    cache.Store
+	logger   logr.Logger
+}
+
+// Purge calls onPurge for objects that do not exist in the cache but have not been deleted in ES.
+func (e *ESPurger) Purge(ctx context.Context, syncBefore time.Time) error {
+	resource := e.gvr.Resource
+	kind := resource[0 : len(resource)-1]
+
+	query := make(map[string]interface{})
+	query["query"] = esquery.Bool().Must(
+		esquery.Term("cluster", e.cluster),
+		esquery.Term("apiVersion", e.gvr.GroupVersion().String()),
+		esquery.Term("kind", kind),
+		esquery.Term("deleted", false),
+		esquery.Range("syncAt").Lte(syncBefore),
+	).Map()
+
+	sr, err := e.esClient.SearchByQuery(context.Background(), query, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range sr.Resources {
+		obj := &unstructured.Unstructured{}
+		obj.SetUnstructuredContent(r.Object)
+		key, err := cache.MetaNamespaceKeyFunc(obj)
+		if err != nil {
+			e.logger.Error(err, "error in getting object key")
+			continue
+		}
+
+		_, exist, err := e.store.GetByKey(key)
+		if err != nil {
+			e.logger.Error(err, "error in getting object by key")
+			continue
+		}
+
+		if !exist {
+			e.logger.V(1).Info("found an object that should be purged", "key", key)
+			e.onPurge(obj)
+		}
+	}
+
+	return nil
+}

--- a/ui/src/pages/insightDetail/components/sourceTable/index.tsx
+++ b/ui/src/pages/insightDetail/components/sourceTable/index.tsx
@@ -1,5 +1,5 @@
 import { SearchOutlined } from '@ant-design/icons'
-import { Button, Input, Space, Table } from 'antd'
+import { Button, Input, Space, Table, Tag } from 'antd'
 import queryString from 'query-string'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -37,6 +37,7 @@ const SourceTable = ({ queryStr, tableName }: IProps) => {
   function goResourcePage(record) {
     const nav = record?.object?.kind === 'Namespace' ? 'namespace' : 'resource'
     const params = {
+      deleted: record?.deleted,
       from: urlSearchParams?.from,
       type: nav,
       query: urlSearchParams?.query,
@@ -85,6 +86,14 @@ const SourceTable = ({ queryStr, tableName }: IProps) => {
       key: 'kind',
       title: 'Kind',
       render: (_, record) => record?.object?.kind,
+    },
+    {
+      dataIndex: 'deleted',
+      key: 'deleted',
+      title: 'status',
+      render: text => {
+        return text ? <Tag color="error">{t('Deleted')}</Tag> : null
+      },
     },
   ]
 

--- a/ui/src/pages/insightDetail/namespace/index.tsx
+++ b/ui/src/pages/insightDetail/namespace/index.tsx
@@ -44,6 +44,22 @@ const ClusterDetail = () => {
   const [multiTopologyData, setMultiTopologyData] = useState<any>()
   const [selectedCluster, setSelectedCluster] = useState<any>()
   const [clusterOptions, setClusterOptions] = useState<string[]>([])
+  const [tabList, setTabList] = useState(insightTabsList)
+
+  useEffect(() => {
+    if (urlParams?.deleted) {
+      const tmp = tabList?.map(item => {
+        if (item?.value === 'Topology' && urlParams?.deleted) {
+          item.disabled = true
+        }
+        return item
+      })
+      setTabList(tmp)
+    } else {
+      setTabList(insightTabsList)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlParams])
 
   useEffect(() => {
     if (selectedCluster) {
@@ -398,16 +414,10 @@ const ClusterDetail = () => {
         </div>
       </div>
 
-      {/* 拓扑图 */}
       <div className={styles.tab_content}>
         <div className={styles.tab_header}>
           <KarporTabs
-            list={insightTabsList?.map(item => {
-              if (item?.value === 'Topology' && urlParams?.deleted) {
-                item.disabled = true
-              }
-              return item
-            })}
+            list={tabList}
             current={currentTab}
             onChange={handleTabChange}
           />

--- a/ui/src/pages/insightDetail/namespace/index.tsx
+++ b/ui/src/pages/insightDetail/namespace/index.tsx
@@ -30,7 +30,7 @@ const ClusterDetail = () => {
   const [drawerVisible, setDrawerVisible] = useState<boolean>(false)
   const [k8sDrawerVisible, setK8sDrawerVisible] = useState<boolean>(false)
   const [currentTab, setCurrentTab] = useState(
-    urlParams?.deleted ? 'YAML' : 'Topology',
+    urlParams?.deleted === 'true' ? 'YAML' : 'Topology',
   )
   const [modalVisible, setModalVisible] = useState<boolean>(false)
   const [tableQueryStr, setTableQueryStr] = useState<any>()
@@ -47,19 +47,25 @@ const ClusterDetail = () => {
   const [tabList, setTabList] = useState(insightTabsList)
 
   useEffect(() => {
-    if (urlParams?.deleted) {
+    if (urlParams?.deleted === 'true') {
       const tmp = tabList?.map(item => {
-        if (item?.value === 'Topology' && urlParams?.deleted) {
+        if (item?.value === 'Topology' && urlParams?.deleted === 'true') {
           item.disabled = true
         }
         return item
       })
       setTabList(tmp)
     } else {
-      setTabList(insightTabsList)
+      const tmp = tabList?.map(item => {
+        if (item?.value === 'Topology') {
+          item.disabled = false
+        }
+        return item
+      })
+      setTabList(tmp)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlParams])
+  }, [urlParams?.deleted])
 
   useEffect(() => {
     if (selectedCluster) {
@@ -207,7 +213,7 @@ const ClusterDetail = () => {
   }, [topologyDataResponse])
 
   function getTopologyData() {
-    if (urlParams?.deleted) return
+    if (urlParams?.deleted === 'true') return
     topologyDataRefetch({
       option: {
         params: {

--- a/ui/src/pages/insightDetail/namespace/index.tsx
+++ b/ui/src/pages/insightDetail/namespace/index.tsx
@@ -29,7 +29,9 @@ const ClusterDetail = () => {
     urlParams
   const [drawerVisible, setDrawerVisible] = useState<boolean>(false)
   const [k8sDrawerVisible, setK8sDrawerVisible] = useState<boolean>(false)
-  const [currentTab, setCurrentTab] = useState('Topology')
+  const [currentTab, setCurrentTab] = useState(
+    urlParams?.deleted ? 'YAML' : 'Topology',
+  )
   const [modalVisible, setModalVisible] = useState<boolean>(false)
   const [tableQueryStr, setTableQueryStr] = useState<any>()
   const [yamlData, setYamlData] = useState('')
@@ -189,6 +191,7 @@ const ClusterDetail = () => {
   }, [topologyDataResponse])
 
   function getTopologyData() {
+    if (urlParams?.deleted) return
     topologyDataRefetch({
       option: {
         params: {
@@ -399,7 +402,12 @@ const ClusterDetail = () => {
       <div className={styles.tab_content}>
         <div className={styles.tab_header}>
           <KarporTabs
-            list={insightTabsList}
+            list={insightTabsList?.map(item => {
+              if (item?.value === 'Topology' && urlParams?.deleted) {
+                item.disabled = true
+              }
+              return item
+            })}
             current={currentTab}
             onChange={handleTabChange}
           />

--- a/ui/src/pages/insightDetail/namespace/index.tsx
+++ b/ui/src/pages/insightDetail/namespace/index.tsx
@@ -214,6 +214,7 @@ const ClusterDetail = () => {
 
   function getTopologyData() {
     if (urlParams?.deleted === 'true') return
+
     topologyDataRefetch({
       option: {
         params: {

--- a/ui/src/pages/insightDetail/resource/index.tsx
+++ b/ui/src/pages/insightDetail/resource/index.tsx
@@ -29,7 +29,7 @@ const ClusterDetail = () => {
   const [drawerVisible, setDrawerVisible] = useState<boolean>(false)
   const [k8sDrawerVisible, setK8sDrawerVisible] = useState<boolean>(false)
   const [currentTab, setCurrentTab] = useState(
-    urlParams?.deleted ? 'YAML' : 'Topology',
+    urlParams?.deleted === 'true' ? 'YAML' : 'Topology',
   )
   const [modalVisible, setModalVisible] = useState<boolean>(false)
   const [yamlData, setYamlData] = useState('')
@@ -45,19 +45,25 @@ const ClusterDetail = () => {
   const [tabList, setTabList] = useState(insightTabsList)
 
   useEffect(() => {
-    if (urlParams?.deleted) {
+    if (urlParams?.deleted === 'true') {
       const tmp = tabList?.map(item => {
-        if (item?.value === 'Topology' && urlParams?.deleted) {
+        if (item?.value === 'Topology' && urlParams?.deleted === 'true') {
           item.disabled = true
         }
         return item
       })
       setTabList(tmp)
     } else {
-      setTabList(insightTabsList)
+      const tmp = tabList?.map(item => {
+        if (item?.value === 'Topology') {
+          item.disabled = false
+        }
+        return item
+      })
+      setTabList(tmp)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlParams])
+  }, [urlParams?.deleted])
 
   function handleTabChange(value: string) {
     setCurrentTab(value)
@@ -189,7 +195,7 @@ const ClusterDetail = () => {
   }, [topologyDataResponse])
 
   function getTopologyData() {
-    if (urlParams?.deleted) return
+    if (urlParams?.deleted === 'true') return
     topologyDataRefetch({
       option: {
         params: {

--- a/ui/src/pages/insightDetail/resource/index.tsx
+++ b/ui/src/pages/insightDetail/resource/index.tsx
@@ -8,6 +8,7 @@ import Yaml from '@/components/yaml'
 import { capitalized, generateResourceTopologyData } from '@/utils/tools'
 import { insightTabsList } from '@/utils/constants'
 import { ICON_MAP } from '@/utils/images'
+import { useAxios } from '@/utils/request'
 import ExceptionDrawer from '../components/exceptionDrawer'
 import TopologyMap from '../components/topologyMap'
 import ExceptionList from '../components/exceptionList'
@@ -17,7 +18,6 @@ import K8sEventDrawer from '../components/k8sEventDrawer'
 import SummaryCard from '../components/summaryCard'
 
 import styles from './styles.module.less'
-import { useAxios } from '@/utils/request'
 
 const ClusterDetail = () => {
   const { t, i18n } = useTranslation()
@@ -41,6 +41,23 @@ const ClusterDetail = () => {
   const [multiTopologyData, setMultiTopologyData] = useState<any>()
   const [selectedCluster, setSelectedCluster] = useState<any>()
   const [clusterOptions, setClusterOptions] = useState<string[]>([])
+
+  const [tabList, setTabList] = useState(insightTabsList)
+
+  useEffect(() => {
+    if (urlParams?.deleted) {
+      const tmp = tabList?.map(item => {
+        if (item?.value === 'Topology' && urlParams?.deleted) {
+          item.disabled = true
+        }
+        return item
+      })
+      setTabList(tmp)
+    } else {
+      setTabList(insightTabsList)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlParams])
 
   function handleTabChange(value: string) {
     setCurrentTab(value)
@@ -393,12 +410,7 @@ const ClusterDetail = () => {
       <div className={styles.tab_content}>
         <div className={styles.tab_header}>
           <KarporTabs
-            list={insightTabsList?.map(item => {
-              if (item?.value === 'Topology' && urlParams?.deleted) {
-                item.disabled = true
-              }
-              return item
-            })}
+            list={tabList}
             current={currentTab}
             onChange={handleTabChange}
           />

--- a/ui/src/pages/insightDetail/resource/index.tsx
+++ b/ui/src/pages/insightDetail/resource/index.tsx
@@ -28,7 +28,9 @@ const ClusterDetail = () => {
     urlParams
   const [drawerVisible, setDrawerVisible] = useState<boolean>(false)
   const [k8sDrawerVisible, setK8sDrawerVisible] = useState<boolean>(false)
-  const [currentTab, setCurrentTab] = useState('Topology')
+  const [currentTab, setCurrentTab] = useState(
+    urlParams?.deleted ? 'YAML' : 'Topology',
+  )
   const [modalVisible, setModalVisible] = useState<boolean>(false)
   const [yamlData, setYamlData] = useState('')
   const [auditList, setAuditList] = useState<any>([])
@@ -170,6 +172,7 @@ const ClusterDetail = () => {
   }, [topologyDataResponse])
 
   function getTopologyData() {
+    if (urlParams?.deleted) return
     topologyDataRefetch({
       option: {
         params: {
@@ -390,7 +393,12 @@ const ClusterDetail = () => {
       <div className={styles.tab_content}>
         <div className={styles.tab_header}>
           <KarporTabs
-            list={insightTabsList}
+            list={insightTabsList?.map(item => {
+              if (item?.value === 'Topology' && urlParams?.deleted) {
+                item.disabled = true
+              }
+              return item
+            })}
             current={currentTab}
             onChange={handleTabChange}
           />

--- a/ui/src/pages/result/index.tsx
+++ b/ui/src/pages/result/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Pagination, Empty, Divider, Tooltip } from 'antd'
+import { Pagination, Empty, Divider, Tooltip, Tag } from 'antd'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ClockCircleOutlined } from '@ant-design/icons'
@@ -98,6 +98,7 @@ const Result = () => {
     const nav = key === 'name' ? 'resource' : key
     const objParams = {
       from: 'result',
+      deleted: item?.deleted,
       cluster: item?.cluster,
       apiVersion: item?.object?.apiVersion,
       type: key,
@@ -114,6 +115,7 @@ const Result = () => {
     const nav = kind === 'Namespace' ? 'namespace' : 'resource'
     const objParams = {
       from: 'result',
+      deleted: item?.deleted,
       cluster: item?.cluster,
       apiVersion: item?.object?.apiVersion,
       type: nav,
@@ -170,6 +172,11 @@ const Result = () => {
         {pageData?.map((item: any, index: number) => {
           return (
             <div className={styles.card} key={`${item?.name}_${index}`}>
+              {item?.deleted && (
+                <div className={styles.delete_tag}>
+                  <Tag color="error">{t('Delete')}</Tag>
+                </div>
+              )}
               <div className={styles.left}>
                 <img
                   src={ICON_MAP?.[item?.object?.kind] || ICON_MAP.CRD}

--- a/ui/src/pages/result/styles.module.less
+++ b/ui/src/pages/result/styles.module.less
@@ -52,6 +52,13 @@
       border-radius: 8px;
       box-sizing: border-box;
       align-items: center;
+      position: relative;
+
+      .delete_tag {
+        position: absolute;
+        right: 10px;
+        top: 10px;
+      }
 
       .left {
         width: 48px;

--- a/ui/src/pages/result/styles.module.less
+++ b/ui/src/pages/result/styles.module.less
@@ -44,6 +44,7 @@
     }
 
     .card {
+      position: relative;
       display: flex;
       width: 100%;
       padding: 16px 24px;
@@ -52,12 +53,11 @@
       border-radius: 8px;
       box-sizing: border-box;
       align-items: center;
-      position: relative;
 
       .delete_tag {
         position: absolute;
-        right: 10px;
         top: 10px;
+        right: 10px;
       }
 
       .left {


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it:

In the current implementation, the lifecycle of storage data is bound to object in cluster. When an object is deleted in cluster, the associated data in storage will also be cleared.

Events in cluster are retained for one hour by default. As key information for troubleshooting, it is usually hoped that events can be retained for a longer time, which requires karpor to unbind the lifecycle of specific types of resources from cluster.

This PR adds a `remainAfterDeleted` field in the SyncRegistry CRD to control that a certain type of resources remain in storage after being deleted in cluster.

If the user sets `remainAfterDeleted=true` for a type of resource, the user needs to delete the associated data in the storage by himself. Karpor only marks `deleted=true` for storage data when the object is deleted in cluster.

For resources that leave `remainAfterDeleted` unset (`remainAfterDeleted=false`), the data in storage will be deleted immediately after the cluster object is deleted.

```yaml
apiVersion: search.karpor.io/v1beta1
kind: SyncRegistry
metadata:
  name: events-sync-rule
spec:
  clusters:
    - "*"
  syncResources:
    - apiVersion: v1
      resource: events
      trimRefName: for-events
      remainAfterDeleted: true
```

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #
