### PR TITLE
fix: wrong swagger args of gen-api-spec in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,14 +150,14 @@ fix-license:  ## Adds missing license header to repo files
 gen-api-spec: ## Generate API Specification with OpenAPI format
 	@which swag > /dev/null || (echo "Installing swag@v1.7.8 ..."; go install github.com/swaggo/swag/cmd/swag@v1.7.8 && echo "Installation complete!\n")
 	# Generate API documentation with OpenAPI format
-	-swag init --parseDependency --parseInternal --parseDepth 1 -g cmd/main.go -o api/openapispec/ && echo "🎉 Done!" || (echo "💥 Fail!"; exit 1)
+	@swag init --parseDependency --parseInternal --parseDepth 1 -g cmd/karpor/main.go -o api/openapispec/ && echo "🎉 Done!" || (echo "💥 Fail!"; exit 1)
 	# Format swagger comments
-	-swag fmt -g pkg/**/*.go && echo "🎉 Done!" || (echo "💥 Failed!"; exit 1)
+	@swag fmt -g pkg/**/*.go && echo "🎉 Done!" || (echo "💥 Failed!"; exit 1)
 
 .PHONY: gen-api-doc
 gen-api-doc: gen-api-spec ## Generate API Documentation by API Specification
 	@which swagger > /dev/null || (echo "Installing swagger@v0.30.5 ..."; go install github.com/go-swagger/go-swagger/cmd/swagger@v0.30.5 && echo "Installation complete!\n")
-	-swagger generate markdown -f ./api/openapispec/swagger.json --output=docs/api.md && echo "🎉 Done!" || (echo "💥 Fail!"; exit 1)
+	@swagger generate markdown -f ./api/openapispec/swagger.json --output=docs/api.md && echo "🎉 Done!" || (echo "💥 Fail!"; exit 1)
 
 .PHONY: gen-cli-doc
 gen-cli-doc: ## Generate CLI Documentation


### PR DESCRIPTION
## What type of PR is this?

/kind chore

## What this PR does / why we need it:

Fix wrong swagger args of gen-api-spec in Makefile

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #
