### PR TITLE
docs: update Slack channels in README

### DIFF
--- a/README-pt.md
+++ b/README-pt.md
@@ -172,4 +172,6 @@ Agradecemos a essas pessoas maravilhosas! Venha e [junte-se](https://kusionstack
 
 Caso tenha alguma pergunta, sinta-se à vontade para entrar em contato conosco pelos seguintes meios:
 
-- [Slack](https://kusionstack.slack.com) | [Junte-se](https://join.slack.com/t/kusionstack/shared_invite/zt-2drafxksz-VzCZZwlraHP4xpPeh_g8lg)
+- **Canais do Slack:**
+  - [#kusion](https://cloud-native.slack.com/archives/C07U0395UG0) - Discussões técnicas sobre Karpor e KusionStack
+  - [#kusion-general](https://cloud-native.slack.com/archives/C07T4LBDB7G) - Discussões gerais, anúncios e atualizações da comunidade

--- a/README-zh.md
+++ b/README-zh.md
@@ -175,7 +175,9 @@ Karpor 仍处于初期阶段，仍有许多功能需要构建，因此我们欢�
 
 如果您有任何问题，欢迎通过以下方式联系我们：
 
-- [Slack](https://kusionstack.slack.com) | [加入](https://join.slack.com/t/kusionstack/shared_invite/zt-2drafxksz-VzCZZwlraHP4xpPeh_g8lg)
+- **Slack 频道：**
+  - [#kusion](https://cloud-native.slack.com/archives/C07U0395UG0) - Karpor 和 KusionStack 的技术讨论
+  - [#kusion-general](https://cloud-native.slack.com/archives/C07T4LBDB7G) - 一般性讨论、公告和社区动态
 - [钉钉群](https://page.dingtalk.com/wow/dingtalk/act/en-home)：`42753001`（中文）
 - 微信群（中文）：添加微信小助手，拉你进用户群
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ Thanks to these wonderful people! Come and [join us](https://kusionstack.io/karp
 
 If you have any questions, feel free to reach out to us in the following ways:
 
-- [Slack](https://kusionstack.slack.com) | [Join](https://join.slack.com/t/kusionstack/shared_invite/zt-2drafxksz-VzCZZwlraHP4xpPeh_g8lg)
+- **Slack Channels:**
+  - [#kusion](https://cloud-native.slack.com/archives/C07U0395UG0) - Technical discussions about Karpor and KusionStack
+  - [#kusion-general](https://cloud-native.slack.com/archives/C07T4LBDB7G) - General discussions, announcements, and community updates
 - [DingTalk Group](https://page.dingtalk.com/wow/dingtalk/act/en-home): `42753001`  (Chinese)
 - WeChat Group (Chinese): Add the WeChat assistant to bring you into the user group.
 


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does / why we need it:

This PR updates the Slack channel links in the README files to point to the cloud-native workspace. It also adds descriptions to distinguish between the #kusion and #kusion-general channels. The changes are applied to all README versions (English, Chinese, Portuguese) and the formatting is improved with clear channel section headers.

## Which issue(s) this PR fixes:

Fixes #
