### PR TITLE
fix: ignore FOSSA badge links in markdown link check

### DIFF
--- a/.github/workflows/constraint.yaml
+++ b/.github/workflows/constraint.yaml
@@ -31,3 +31,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,11 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://app.fossa.com/api/projects/git%2Bgithub.com%2FKusionStack%2Fkarpor.svg"
+    }
+  ],
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s"
+}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

This PR configures markdown-link-check to ignore FOSSA badge URLs that are incorrectly reported as dead links. The links are actually accessible but were being flagged as 404 errors.

## Which issue(s) this PR fixes:

Fixes #
