### PR TITLE
chore: exclude additional directories from test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ gen-version: ## Generate version file
 .PHONY: test
 test:  ## Run the tests
 	@PKG_LIST=$${TARGET_PKG:-$(GOSOURCE_PATHS)}; \
-	go test -gcflags=all=-l -timeout=10m `go list -e $${PKG_LIST} | grep -vE "internalimport|generated|handler"` ${TEST_FLAGS}
+	go test -gcflags=all=-l -timeout=10m `go list -e $${PKG_LIST} | grep -vE "cmd|internal|internalimport|generated|handler|registry|openapi|apis"` ${TEST_FLAGS}
 
 
 # cover: Generates a coverage report for the specified TARGET_PKG or default GOSOURCE_PATHS.
@@ -53,7 +53,7 @@ test:  ## Run the tests
 cover: ## Generates coverage report
 	@PKG_LIST=$${TARGET_PKG:-$(GOSOURCE_PATHS)}; \
 	echo "🚀 Executing unit tests for $${PKG_LIST}:"; \
-	go test -gcflags=all=-l -timeout=10m `go list $${PKG_LIST} | grep -vE "internalimport|generated|handler"` -coverprofile $(COVERAGEOUT) ${TEST_FLAGS} && \
+	go test -gcflags=all=-l -timeout=10m `go list $${PKG_LIST} | grep -vE "cmd|internal|internalimport|generated|handler|registry|openapi|apis"` -coverprofile $(COVERAGEOUT) ${TEST_FLAGS} && \
 	(echo "\n📊 Calculating coverage rate:"; go tool cover -func=$(COVERAGEOUT)) || (echo "\n💥 Running go test failed!"; exit 1)
 
 


### PR DESCRIPTION
## What type of PR is this?

/kind chore

## What this PR does / why we need it:

This PR updates the Makefile to exclude additional directories from test coverage. This is necessary to ensure that irrelevant directories are not included in the test coverage report, which can lead to misleading results and unnecessary noise in the coverage metrics.

## Which issue(s) this PR fixes:

Fixes #
