### PR TITLE
fix(pod-logs): resolve log flickering and duplication during SSE reconnection

### DIFF
--- a/ui/src/pages/insightDetail/components/podLogs/styles.module.less
+++ b/ui/src/pages/insightDetail/components/podLogs/styles.module.less
@@ -712,7 +712,8 @@
           border-color: #4096ff;
         }
 
-        &:focus, &-focused {
+        &:focus,
+        &-focused {
           border-color: #1677ff;
           box-shadow: 0 0 0 2px rgba(5, 145, 255, 0.1);
         }
@@ -729,7 +730,7 @@
 
       .ant-input-clear-icon {
         color: rgba(0, 0, 0, 0.25);
-        
+
         &:hover {
           color: rgba(0, 0, 0, 0.45);
         }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

This PR addresses issues related to log flickering and duplication during Server-Sent Events (SSE) reconnection in the pod logs feature. The changes include:
- **Fix log duplication:**
  - Implement robust log deduplication by generating unique log IDs using timestamps and content.
  - Prevent duplicate logs from appearing during SSE reconnection.
  - Clear logs when settings are changed to avoid stale data.
- **Optimize SSE connection handling:**
  - Improve reconnection logic to ensure smoother transitions.
  - Prevent UI flickering during reconnection.
  - Enhance error handling for connection failures to improve reliability.
- **Enhance log viewer user experience:**
  - Improve the settings modal UI and behavior for better usability.
  - Modify the download functionality to save only filtered logs.
  - Optimize URL parameter construction for better performance.

## Which issue(s) this PR fixes:

Fixes #
