### PR TITLE
feat: add Status of Pod in search result and source table

### DIFF
--- a/ui/src/hooks/usePodStatus.ts
+++ b/ui/src/hooks/usePodStatus.ts
@@ -1,0 +1,55 @@
+import { useAxios } from '@/utils/request'
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+export const usePodStatus = (
+  cluster: string,
+  namespace: string,
+  name: string,
+) => {
+  const statusRef = useRef<string>('Loading')
+  const [loading, setLoading] = useState(true)
+  const initialized = useRef(false)
+
+  const { response: summaryResponse, refetch: summaryRefetch } = useAxios({
+    url: '/rest-api/v1/insight/summary',
+    method: 'GET',
+    manual: true,
+  })
+
+  useEffect(() => {
+    if (summaryResponse?.success) {
+      statusRef.current = summaryResponse?.data?.resource?.status || 'unknown'
+      setLoading(false)
+    } else {
+      statusRef.current = 'Loading'
+      setLoading(true)
+    }
+  }, [summaryResponse])
+
+  const fetchStatus = useCallback(() => {
+    if (cluster && namespace && name) {
+      summaryRefetch({
+        option: {
+          params: {
+            cluster,
+            apiVersion: 'v1',
+            namespace,
+            kind: 'Pod',
+            name,
+          },
+        },
+      })
+    }
+  }, [cluster, namespace, name, summaryRefetch])
+
+  // Only execute once when component is first mounted
+  useEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true
+      fetchStatus()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { status: statusRef, loading, refetch: fetchStatus }
+}

--- a/ui/src/hooks/usePodStatus.ts
+++ b/ui/src/hooks/usePodStatus.ts
@@ -1,5 +1,6 @@
 import { useAxios } from '@/utils/request'
 import { useState, useEffect, useRef, useCallback } from 'react'
+import axios from 'axios'
 
 export const usePodStatus = (
   cluster: string,
@@ -11,7 +12,7 @@ export const usePodStatus = (
   const initialized = useRef(false)
 
   const { response: summaryResponse, refetch: summaryRefetch } = useAxios({
-    url: '/rest-api/v1/insight/summary',
+    url: `${axios.defaults.baseURL}/rest-api/v1/insight/summary`,
     method: 'GET',
     manual: true,
   })

--- a/ui/src/pages/insightDetail/components/sourceTable/index.tsx
+++ b/ui/src/pages/insightDetail/components/sourceTable/index.tsx
@@ -1,10 +1,11 @@
-import { SearchOutlined } from '@ant-design/icons'
+import { SearchOutlined, LoadingOutlined } from '@ant-design/icons'
 import { Button, Input, Space, Table, Tag } from 'antd'
 import queryString from 'query-string'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 import useDebounce from '@/hooks/useDebounce'
+import { usePodStatus } from '@/hooks/usePodStatus'
 import { useAxios } from '@/utils/request'
 
 import styles from './style.module.less'
@@ -21,6 +22,21 @@ const defaultSearchParams = {
   current: 1,
   pageSize: 10,
   total: 0,
+}
+
+export const PodStatusCell = ({ cluster, namespace, name }) => {
+  const { status, loading } = usePodStatus(cluster, namespace, name)
+  if (loading) {
+    return <LoadingOutlined />
+  }
+  const color =
+    {
+      Running: 'success',
+      Terminating: 'default',
+      Unknown: 'error',
+    }[status.current] || 'warning'
+
+  return <Tag color={color}>{status.current}</Tag>
 }
 
 const SourceTable = ({ queryStr, tableName }: IProps) => {
@@ -64,6 +80,22 @@ const SourceTable = ({ queryStr, tableName }: IProps) => {
         </Button>
       ),
     },
+    ...(tableName === 'Pod'
+      ? [
+          {
+            dataIndex: 'status',
+            key: 'status',
+            title: 'Status',
+            render: (_, record) => (
+              <PodStatusCell
+                cluster={record?.cluster}
+                namespace={record?.object?.metadata?.namespace}
+                name={record?.object?.metadata?.name}
+              />
+            ),
+          },
+        ]
+      : []),
     {
       dataIndex: 'cluster',
       key: 'cluster',
@@ -86,14 +118,6 @@ const SourceTable = ({ queryStr, tableName }: IProps) => {
       key: 'kind',
       title: 'Kind',
       render: (_, record) => record?.object?.kind,
-    },
-    {
-      dataIndex: 'deleted',
-      key: 'deleted',
-      title: 'status',
-      render: text => {
-        return text ? <Tag color="error">{t('Deleted')}</Tag> : null
-      },
     },
   ]
 

--- a/ui/src/pages/insightDetail/components/summaryCard/index.tsx
+++ b/ui/src/pages/insightDetail/components/summaryCard/index.tsx
@@ -5,7 +5,6 @@ import queryString from 'query-string'
 import { useTranslation } from 'react-i18next'
 import { getDataType } from '@/utils/tools'
 import dayjs from 'dayjs'
-import classNames from 'classnames'
 
 import styles from './styles.module.less'
 
@@ -343,19 +342,14 @@ const SummaryCard = ({ auditStat, summary }: SummaryCardProps) => {
               <div className={styles.item}>
                 <div className={styles.label}>Status </div>
                 <Tag
-                  className={classNames(styles.status, {
-                    [styles['status-running']]:
-                      summary?.resource?.status === 'Running',
-                    [styles['status-terminated']]:
-                      summary?.resource?.status === 'Terminated',
-                    [styles['status-unknown']]:
-                      summary?.resource?.status === 'Unknown',
-                    [styles['status-default']]: ![
-                      'Running',
-                      'Terminated',
-                      'Unknown',
-                    ].includes(summary?.resource?.status),
-                  })}
+                  className={styles.status}
+                  color={
+                    {
+                      Running: 'success',
+                      Terminating: 'default',
+                      Unknown: 'error',
+                    }[summary?.resource?.status] || 'warning'
+                  }
                 >
                   {summary?.resource?.status}
                 </Tag>

--- a/ui/src/pages/insightDetail/components/summaryCard/styles.module.less
+++ b/ui/src/pages/insightDetail/components/summaryCard/styles.module.less
@@ -22,58 +22,6 @@
   }
 }
 
-.status {
-  min-width: 54px;
-  position: relative;
-  overflow: hidden;
-
-  &-running {
-    color: #52c41a;
-    background: #f6ffed;
-    border-color: #b7eb8f;
-
-    &:hover {
-      background: #f6ffed;
-    }
-  }
-
-  &-unknown {
-    background: #fff2e8;
-    border-color: #ffbb96;
-    color: #fa541c;
-
-    &:hover {
-      background: #fff7e6;
-    }
-  }
-  &-terminated {
-    background: #989897;
-    border-color: #353434;
-    color: #353434;
-    &:hover {
-      background: #fff7e6;
-    }
-  }
-  &-unknown {
-    color: #ff4d4f;
-    background: #fff2f0;
-    border-color: #ffccc7;
-
-    &:hover {
-      background: #fff7e6;
-    }
-  }
-  &-default {
-    color: #faad14;
-    background: #fffbe6;
-    border-color: #ffe58f;
-
-    &:hover {
-      background: #fff7e6;
-    }
-  }
-}
-
 .summary {
   display: flex;
   padding: 0 20px;

--- a/ui/src/pages/result/index.tsx
+++ b/ui/src/pages/result/index.tsx
@@ -27,6 +27,7 @@ import Loading from '@/components/loading'
 import { ICON_MAP } from '@/utils/images'
 import { searchSqlPrefix, tabsList } from '@/utils/constants'
 import { useAxios } from '@/utils/request'
+import { PodStatusCell } from '@/pages/insightDetail/components/sourceTable'
 // import useDebounce from '@/hooks/useDebounce'
 
 import styles from './styles.module.less'
@@ -297,7 +298,16 @@ const Result = () => {
                   className={styles.top}
                   onClick={() => handleTitleClick(item, item?.object?.kind)}
                 >
-                  {item?.object?.metadata?.name || '--'}
+                  <span style={{ marginRight: 8 }}>
+                    {item?.object?.metadata?.name || '--'}
+                  </span>
+                  {item?.object?.kind === 'Pod' && (
+                    <PodStatusCell
+                      cluster={item?.cluster}
+                      namespace={item?.object?.metadata?.namespace}
+                      name={item?.object?.metadata?.name}
+                    />
+                  )}
                 </div>
                 <div className={styles.bottom}>
                   <div


### PR DESCRIPTION
## What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind refactor
/kind documentation

/kind chore
/kind perf
/kind style
/kind test
-->

## What this PR does / why we need it:

This PR adds Pod status in search result and source tables:
 
![image](https://github.com/user-attachments/assets/0212f62f-5aef-410f-ad18-dbf94eaa49e7)
----------––--
![image](https://github.com/user-attachments/assets/c5bcca57-f70e-4397-a860-6277c92135b8)


## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #
