### PR TITLE
fix: handle server version error with default value

### DIFF
--- a/pkg/core/manager/insight/summary.go
+++ b/pkg/core/manager/insight/summary.go
@@ -38,9 +38,10 @@ const (
 func (i *InsightManager) GetDetailsForCluster(ctx context.Context, client *multicluster.MultiClusterClient, name string) (*ClusterDetail, error) {
 	// get server version and measure latency
 	start := time.Now()
+	serverVersionStr := "v0.0.0-unknown" // default version when error occurs
 	serverVersion, err := client.ClientSet.DiscoveryClient.ServerVersion()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get server version: %w", err)
+	if err == nil {
+		serverVersionStr = serverVersion.String()
 	}
 	latency := time.Since(start).Milliseconds()
 
@@ -135,7 +136,7 @@ func (i *InsightManager) GetDetailsForCluster(ctx context.Context, client *multi
 
 	return &ClusterDetail{
 		NodeCount:      len(nodes.Items),
-		ServerVersion:  serverVersion.String(),
+		ServerVersion:  serverVersionStr,
 		MemoryCapacity: memoryCapacity,
 		MemoryUsage:    memoryUsage,
 		CPUCapacity:    cpuCapacity,


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

This PR addresses an issue where the function fails when the server version cannot be retrieved.

- Adds a default server version string 'v0.0.0-unknown' as a fallback value when an error occurs.

This ensures that the function continues to operate without failing and provides a consistent value in case of errors.

![image](https://github.com/user-attachments/assets/1254906c-724d-481f-a76c-641940db7f99)


## Which issue(s) this PR fixes:

Fixes #
