### PR TITLE
fix: allow non-GET requests for paths ending with /stream

### DIFF
--- a/pkg/core/middleware/readonly.go
+++ b/pkg/core/middleware/readonly.go
@@ -16,12 +16,13 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 )
 
 // ReadOnlyMode disallows non-GET requests in read-only mode.
 func ReadOnlyMode(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
+		if r.Method != http.MethodGet && !strings.HasSuffix(r.URL.Path, "/stream") {
 			http.Error(w, "The server is currently in read-only mode.", http.StatusMethodNotAllowed)
 			return
 		}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

This PR modifies the ReadOnlyMode middleware to allow non-GET requests for URLs ending with '/stream'.

Key changes include:
- Adjusting the middleware logic to permit non-GET requests for paths ending with '/stream'.
- Ensuring streaming endpoints remain functional in read-only mode, addressing a specific use case where streaming data is required.

## Which issue(s) this PR fixes:

Fixes #
