### PR TITLE
feat: add milestone planning workflow

### DIFF
--- a/.github/workflows/milestone-summary.yml
+++ b/.github/workflows/milestone-summary.yml
@@ -1,0 +1,35 @@
+name: Milestone Planning
+
+on:
+  # Trigger on milestone events
+  milestone:
+    types: [created, edited, deleted]
+  # Trigger on issue events
+  issues:
+    types: [opened, edited, deleted, transferred, milestoned, demilestoned]
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Milestone Planning
+        uses: elliotxx/auto-milestone-summary-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          planning_label: planning
+          categories: |
+            [
+              "area/ai",
+              "area/search",
+              "area/insight",
+              "area/cluster-mgmt",
+              "area/experience",
+              "area/installation",
+              "area/performance",
+              "area/server",
+              "area/storage",
+              "area/syncer",
+              "bug",
+              "enhancement",
+              "documentation"
+            ]


### PR DESCRIPTION
## What type of PR is this?

/kind refactor

## What this PR does / why we need it:

This PR simplifies the milestone-summary workflow by:
- Removing the manual `workflow_dispatch` trigger
- Removing the `push` trigger for specific branches
- Updating the `auto-milestone-summary-action` to the latest version

These changes streamline the workflow by eliminating unnecessary triggers and ensuring the action is up-to-date.

## Which issue(s) this PR fixes:

Fixes #
