### PR TITLE
chore(ci): add labeled and unlabeled events to issue triggers

### DIFF
--- a/.github/workflows/milestone-summary.yml
+++ b/.github/workflows/milestone-summary.yml
@@ -6,7 +6,7 @@ on:
     types: [created, edited, deleted]
   # Trigger on issue events
   issues:
-    types: [opened, edited, deleted, transferred, milestoned, demilestoned]
+    types: [opened, edited, deleted, transferred, milestoned, demilestoned, labeled, unlabeled]
 
 jobs:
   plan:

--- a/.github/workflows/milestone-summary.yml
+++ b/.github/workflows/milestone-summary.yml
@@ -31,5 +31,6 @@ jobs:
               "area/syncer",
               "bug",
               "enhancement",
+              "governance",
               "documentation"
             ]


### PR DESCRIPTION
## What type of PR is this?

/kind chore

## What this PR does / why we need it:

This PR extends the GitHub Actions workflow to include 'labeled' and 'unlabeled' events as triggers. 

- Adds support for 'labeled' and 'unlabeled' events in the issue event types.

## Which issue(s) this PR fixes:

Fixes #
