### PR TITLE
fix: hidden cmdline, memstat and token in serverconfig

### DIFF
--- a/cmd/karpor/app/server.go
+++ b/cmd/karpor/app/server.go
@@ -108,7 +108,9 @@ func NewServerCommand(ctx context.Context) *cobra.Command {
 		return o.SearchStorageOptions
 	}))
 	expvar.Publish("AIOptions", expvar.Func(func() interface{} {
-		return o.AIOptions
+		displayOpts := *o.AIOptions
+		displayOpts.AIAuthToken = "[hidden]"
+		return &displayOpts
 	}))
 	expvar.Publish("Version", expvar.Func(func() interface{} {
 		return version.GetVersion()


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it:

- hidden AI backend token in ServerConfig api
- remove `cmdline` and `memstat` in ServerConfig api

![image](https://github.com/user-attachments/assets/d8677e2d-b62a-4ac6-9132-38a879234507)

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #
