### PR TITLE
chore: add 'integration' to milestone summary categories

### DIFF
--- a/.github/workflows/milestone-summary.yml
+++ b/.github/workflows/milestone-summary.yml
@@ -36,5 +36,6 @@ jobs:
               "security",
               "testing",
               "logistics",
+              "integration",
               "documentation"
             ]


### PR DESCRIPTION
## What type of PR is this?

/kind chore

## What this PR does / why we need it:

- Added 'integration' to the list of categories in the GitHub workflow configuration.
- Ensures that the milestone summary workflow correctly categorizes tasks related to integration.

## Which issue(s) this PR fixes:

Fixes #
