### PR TITLE
chore(ci): rename community-planning-updater action

### DIFF
--- a/.github/workflows/community-planning-updater.yml
+++ b/.github/workflows/community-planning-updater.yml
@@ -1,4 +1,4 @@
-name: Milestone Planning
+name: Community Planning Updater
 
 on:
   # Trigger on milestone events
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Milestone Planning
-        uses: elliotxx/auto-milestone-summary-action@v1
+        uses: elliotxx/community-planning-updater@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           planning_label: planning


### PR DESCRIPTION
## What type of PR is this?

/kind chore

## What this PR does / why we need it:

This PR includes the following changes:
- Renames `.github/workflows/milestone-summary.yml` to `.github/workflows/community-planning-updater.yml`
- Updates the action from `elliotxx/auto-milestone-summary-action@v1` to `elliotxx/community-planning-updater@v1`

These changes align the workflow name and action with its intended purpose of updating community planning, improving clarity and maintainability.

## Which issue(s) this PR fixes:

Fixes #
