### PR TITLE
feat: add assigned and unassigned events to issue triggers

### DIFF
--- a/.github/workflows/community-planning-updater.yml
+++ b/.github/workflows/community-planning-updater.yml
@@ -6,7 +6,7 @@ on:
     types: [created, edited, deleted]
   # Trigger on issue events
   issues:
-    types: [opened, edited, deleted, transferred, milestoned, demilestoned, labeled, unlabeled]
+    types: [opened, edited, deleted, transferred, milestoned, demilestoned, labeled, unlabeled, assigned, unassigned]
 
 jobs:
   plan:


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it:

This PR adds support for 'assigned' and 'unassigned' event types to the GitHub Actions workflow.

Key changes include:
- Updated the workflow to trigger on 'assigned' and 'unassigned' events for issues.
- Ensures better automation and responsiveness to issue management activities.

## Which issue(s) this PR fixes:

Fixes #
