### PR TITLE
chore(ci): add community planning and task updater workflow, power by osp

### DIFF
--- a/.github/workflows/community-task-updater.yml
+++ b/.github/workflows/community-task-updater.yml
@@ -1,9 +1,6 @@
-name: Community Planning Updater
+name: Community Task Updater
 
 on:
-  # Trigger on milestone events
-  milestone:
-    types: [created, edited, deleted]
   # Trigger on issue events
   issues:
     types: [opened, edited, deleted, transferred, milestoned, demilestoned, labeled, unlabeled, assigned, unassigned]
@@ -13,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Community Planning Updater
+      - name: Update Community Tasks
         uses: elliotxx/osp-action@v1
         with:
           # Optional: version of OSP to use (default: latest)
@@ -25,15 +22,18 @@ jobs:
           # Optional: GitHub token (default: ${{ github.token }})
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+          # Optional: enable debug mode (default: false)
+          debug: false
+
           # Optional: skip caching (default: false)
           skip-cache: false
 
-          # Optional: enable debug mode
-          debug: false
-
           # Optional: additional OSP arguments
           args: >-
-            plan
+            onboard
             --dry-run
-            --priority-labels priority/critical,priority/important-soon,priority/important-longterm,priority/awaiting-more-evidence
+            --onboard-labels 'help wanted,good first issue'
+            --difficulty-labels 'easy,medium,hard'
             --category-labels area/cli,area/ai,area/search,area/insight,area/cluster-mgmt,area/experience,area/installation,area/performance,area/server,area/storage,area/syncer,bug,chore,enhancement,governance,security,testing,logistics,integration,documentation
+            --target-title 'Community tasks | 新手任务清单 🎖︎'
+

--- a/.github/workflows/community-task-updater.yml
+++ b/.github/workflows/community-task-updater.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Update Community Tasks
+      - name: Community Tasks Updater
         uses: elliotxx/osp-action@v1
         with:
           # Optional: version of OSP to use (default: latest)


### PR DESCRIPTION
## What type of PR is this?

/kind chore

## What this PR does / why we need it:

This PR refactors the CI/CD process by making the following changes:
- Renames the job from 'plan' to 'osp-run' to better reflect its purpose.
- Updates the action from 'community-planning-updater' to 'osp-action' for improved functionality.
- Introduces a new workflow 'community-task-updater.yml' to manage community tasks more effectively.

These changes enhance the project's ability to manage and onboard new contributors by streamlining the workflow and improving task management.

## Which issue(s) this PR fixes:

Fixes #
