### PR TITLE
chore(ci): remove dry-run from OSP-related CI workflows

### DIFF
--- a/.github/workflows/community-planning-updater.yml
+++ b/.github/workflows/community-planning-updater.yml
@@ -34,6 +34,5 @@ jobs:
           # Optional: additional OSP arguments
           args: >-
             plan
-            --dry-run
             --priority-labels priority/critical,priority/important-soon,priority/important-longterm,priority/awaiting-more-evidence
             --category-labels area/cli,area/ai,area/search,area/insight,area/cluster-mgmt,area/experience,area/installation,area/performance,area/server,area/storage,area/syncer,bug,chore,enhancement,governance,security,testing,logistics,integration,documentation

--- a/.github/workflows/community-task-updater.yml
+++ b/.github/workflows/community-task-updater.yml
@@ -31,7 +31,6 @@ jobs:
           # Optional: additional OSP arguments
           args: >-
             onboard
-            --dry-run
             --onboard-labels 'help wanted,good first issue'
             --difficulty-labels 'easy,medium,hard'
             --category-labels area/cli,area/ai,area/search,area/insight,area/cluster-mgmt,area/experience,area/installation,area/performance,area/server,area/storage,area/syncer,bug,chore,enhancement,governance,security,testing,logistics,integration,documentation


### PR DESCRIPTION
## What type of PR is this?

/kind chore

## What this PR does / why we need it:

**Tested without any problems, officially enabled OSP automatic updates (Planning and Community Tasks).**

This PR removes the `--dry-run` option from OSP-related CI workflows:
- Removes `--dry-run` from the community planning workflow
- Removes `--dry-run` from the community task workflow

The workflows will now make live changes as originally intended. The `--dry-run` option was likely used for testing and is no longer necessary.

## Which issue(s) this PR fixes:

Fixes #
