### PR TITLE
chore(ci): add 'growth' category label to planning updater workflow

### DIFF
--- a/.github/workflows/community-planning-updater.yml
+++ b/.github/workflows/community-planning-updater.yml
@@ -35,4 +35,4 @@ jobs:
           args: >-
             plan
             --priority-labels priority/critical,priority/important-soon,priority/important-longterm,priority/awaiting-more-evidence
-            --category-labels area/cli,area/ai,area/search,area/insight,area/cluster-mgmt,area/experience,area/installation,area/performance,area/server,area/storage,area/syncer,bug,chore,enhancement,governance,security,testing,logistics,integration,documentation
+            --category-labels area/cli,area/ai,area/search,area/insight,area/cluster-mgmt,area/experience,area/installation,area/performance,area/server,area/storage,area/syncer,bug,chore,enhancement,governance,security,testing,logistics,integration,documentation,growth


### PR DESCRIPTION
## What type of PR is this?

/kind chore

## What this PR does / why we need it:

This PR adds the 'growth' category label to the planning updater workflow in GitHub Actions.

Key changes:
- Updated the workflow configuration to include 'growth' as a category label
- Enables better organization and tracking of issues or features related to growth initiatives

## Which issue(s) this PR fixes:

Fixes #
