### PR TITLE
chore(ci): add --yes flag to osp-related workflow

### DIFF
--- a/.github/workflows/community-planning-updater.yml
+++ b/.github/workflows/community-planning-updater.yml
@@ -34,5 +34,6 @@ jobs:
           # Optional: additional OSP arguments
           args: >-
             plan
+            --yes
             --priority-labels priority/critical,priority/important-soon,priority/important-longterm,priority/awaiting-more-evidence
             --category-labels area/cli,area/ai,area/search,area/insight,area/cluster-mgmt,area/experience,area/installation,area/performance,area/server,area/storage,area/syncer,bug,chore,enhancement,governance,security,testing,logistics,integration,documentation,growth

--- a/.github/workflows/community-task-updater.yml
+++ b/.github/workflows/community-task-updater.yml
@@ -31,6 +31,7 @@ jobs:
           # Optional: additional OSP arguments
           args: >-
             onboard
+            --yes
             --onboard-labels 'help wanted,good first issue'
             --difficulty-labels 'easy,medium,hard'
             --category-labels area/cli,area/ai,area/search,area/insight,area/cluster-mgmt,area/experience,area/installation,area/performance,area/server,area/storage,area/syncer,bug,chore,enhancement,governance,security,testing,logistics,integration,documentation


### PR DESCRIPTION
## What type of PR is this?

/kind chore

## What this PR does / why we need it:

This PR adds the '--yes' flag to osp-related workflow commands to automate the confirmation process.

- Added '--yes' to the 'plan' command in `community-planning-updater.yml`
- Added '--yes' to the 'onboard' command in `community-task-updater.yml`

This change improves workflow efficiency by eliminating the need for manual confirmation during execution.

## Which issue(s) this PR fixes:

Fixes #
