### PR TITLE
feat(ai): added a default model for the Deepseek client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,9 +99,6 @@ linters-settings:
       - unreachable
       - unsafeptr
       - unusedresult
-    disable:
-      - buildssa
-      - fieldalignment
     settings:
       printf:
         funcs:

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ CGO_ENABLED ?= 0
 # Check if the SKIP_UI_BUILD flag is set to control the UI building process.
 # If the flag is not set, the BUILD_UI variable is assigned the value 'build-ui'.
 # If the flag is set, the BUILD_UI variable remains empty.
-ifeq ($(SKIP_UI_BUILD),true)
-    BUILD_UI =
-else
+ifndef SKIP_UI_BUILD
     BUILD_UI = build-ui
+else
+    BUILD_UI =
 endif
 
 # If you encounter an error like "panic: permission denied" on MacOS,
@@ -116,7 +116,7 @@ _build-linux:
 	GOOS=linux GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) \
 		$(GO) build -o ./_build/linux/$(APPROOT) \
 		./cmd/karpor || exit 1
-	
+
 .PHONY: _build-windows
 _build-windows:
 	@rm -rf ./_build/windows

--- a/cmd/karpor/app/options/ai.go
+++ b/cmd/karpor/app/options/ai.go
@@ -53,7 +53,11 @@ func (o *AIOptions) ApplyTo(config *registry.ExtraConfig) error {
 	config.AIBackend = o.AIBackend
 	config.AIAuthToken = o.AIAuthToken
 	config.AIBaseURL = o.AIBaseURL
-	config.AIModel = o.AIModel
+	if o.AIBackend != defaultBackend && o.AIModel == defaultModel {
+		config.AIModel = ""
+	} else {
+		config.AIModel = o.AIModel
+	}
 	config.AITemperature = o.AITemperature
 	config.AITopP = o.AITopP
 	config.AIProxyEnabled = o.AIProxyEnabled

--- a/pkg/infra/ai/deepseek.go
+++ b/pkg/infra/ai/deepseek.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	defaultDeepseekBaseURL = "https://api.deepseek.com/v1"
+	defaultDeepseekModel   = "deepseek-chat"
 )
 
 type DeepseekClient struct {
@@ -42,6 +43,9 @@ func (c *DeepseekClient) Configure(cfg AIConfig) error {
 
 	if cfg.ProxyEnabled {
 		defaultConfig.HTTPClient.Transport = GetProxyHTTPClient(cfg)
+	}
+	if cfg.Model == "" {
+		cfg.Model = defaultDeepseekModel
 	}
 
 	client := deepseek.NewClientWithConfig(defaultConfig)

--- a/pkg/version/VERSION
+++ b/pkg/version/VERSION
@@ -1,1 +1,1 @@
-default-version
+v0.6.3-beta.0

--- a/pkg/version/VERSION
+++ b/pkg/version/VERSION
@@ -1,1 +1,1 @@
-v0.6.3-beta.0
+default-version


### PR DESCRIPTION
## What type of PR is this?

/kind refactor

## What this PR does / why we need it:

This PR introduces the following changes:
- Updated the Makefile to use `ifndef` for the SKIP_UI_BUILD flag, improving the build process.
- Adjusted AI options to handle default model settings more effectively.
- Added a default model for the Deepseek client to ensure better defaults.
- Remove buildssa and fieldalignment linters in disable

These changes aim to enhance the build process and AI configuration handling, making the system more robust and user-friendly.

## Which issue(s) this PR fixes:

Fixes #
