### PR TITLE
feat(yaml): add refresh button & refresh on tab switch

### DIFF
--- a/ui/src/components/yaml/index.tsx
+++ b/ui/src/components/yaml/index.tsx
@@ -9,6 +9,7 @@ import {
   PoweroffOutlined,
   FullscreenExitOutlined,
   FullscreenOutlined,
+  ReloadOutlined,
 } from '@ant-design/icons'
 import hljs from 'highlight.js'
 import yaml from 'js-yaml'
@@ -37,6 +38,7 @@ type InterpretStatus =
 type IProps = {
   data: any
   height?: string | number
+  onRefresh?: () => void
 }
 
 const Yaml = (props: IProps) => {
@@ -47,7 +49,7 @@ const Yaml = (props: IProps) => {
   const interpretEndRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   const observerRef = useRef<MutationObserver | null>(null)
-  const { data } = props
+  const { data, onRefresh } = props
   const [moduleHeight, setModuleHeight] = useState<number>(500)
   const [interpretStatus, setInterpretStatus] =
     useState<InterpretStatus>('idle')
@@ -294,6 +296,17 @@ const Yaml = (props: IProps) => {
                             type="text"
                             icon={<FullscreenOutlined />}
                             onClick={handle.enter}
+                          />
+                        </Tooltip>
+                      )}
+                      {!handle.active && onRefresh && (
+                        <Tooltip title={t('YAML.Refresh')}>
+                          <Button
+                            type="primary"
+                            size="small"
+                            onClick={onRefresh}
+                            disabled={!data}
+                            icon={<ReloadOutlined />}
                           />
                         </Tooltip>
                       )}

--- a/ui/src/components/yaml/index.tsx
+++ b/ui/src/components/yaml/index.tsx
@@ -60,6 +60,10 @@ const Yaml = (props: IProps) => {
   const isAIEnabled = aiOptions?.AIModel && aiOptions?.AIAuthToken
 
   useEffect(() => {
+    onRefresh?.()
+  }, [])
+
+  useEffect(() => {
     const yamlStatusJson = yaml2json(data)
     if (yamlRef.current && yamlStatusJson?.data) {
       ;(yamlRef.current as unknown as HTMLElement).innerHTML = hljs.highlight(
@@ -302,10 +306,8 @@ const Yaml = (props: IProps) => {
                       {!handle.active && onRefresh && (
                         <Tooltip title={t('YAML.Refresh')}>
                           <Button
-                            type="primary"
-                            size="small"
+                            type="text"
                             onClick={onRefresh}
-                            disabled={!data}
                             icon={<ReloadOutlined />}
                           />
                         </Tooltip>

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -157,7 +157,8 @@
     "InterpretConnectionError": "Interpretation connection error",
     "FailedToStartInterpret": "Failed to start interpretation",
     "FailedToInterpret": "Failed to interpret",
-    "TabName": "YAML"
+    "TabName": "YAML",
+    "Refresh": "Refresh"
   },
   "Yesterday": "Yesterday",
   "Collapse": "Collapse",

--- a/ui/src/pages/insightDetail/cluster/index.tsx
+++ b/ui/src/pages/insightDetail/cluster/index.tsx
@@ -69,6 +69,9 @@ const ClusterDetail = () => {
 
   function handleTabChange(value: string) {
     setCurrentTab(value)
+    if (value === 'YAML') {
+      getClusterDetail()
+    }
   }
 
   const {
@@ -318,7 +321,7 @@ const ClusterDetail = () => {
       }
     }
     if (currentTab === 'YAML') {
-      return <Yaml data={yamlData || ''} />
+      return <Yaml data={yamlData || ''} onRefresh={getClusterDetail} />
     }
     if (currentTab === 'K8s') {
       return (

--- a/ui/src/pages/insightDetail/cluster/index.tsx
+++ b/ui/src/pages/insightDetail/cluster/index.tsx
@@ -69,9 +69,6 @@ const ClusterDetail = () => {
 
   function handleTabChange(value: string) {
     setCurrentTab(value)
-    if (value === 'YAML') {
-      getClusterDetail()
-    }
   }
 
   const {


### PR DESCRIPTION
## What type of PR is this?

<!--
/kind feature
-->

## What this PR does / why we need it:
add refresh button on yaml tab, that user can refresh yaml data manually(now only in cluster management)
<img width="1164" alt="Clipboard_Screenshot_1741330933" src="https://github.com/user-attachments/assets/355a6c9b-13e3-4772-9fae-5b966b8bf213" />

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #463
