### PR TITLE
feat(yaml): add refresh button & refresh when switch the tab

### DIFF
--- a/ui/src/components/yaml/index.tsx
+++ b/ui/src/components/yaml/index.tsx
@@ -9,6 +9,7 @@ import {
   PoweroffOutlined,
   FullscreenExitOutlined,
   FullscreenOutlined,
+  ReloadOutlined,
 } from '@ant-design/icons'
 import hljs from 'highlight.js'
 import yaml from 'js-yaml'
@@ -37,6 +38,7 @@ type InterpretStatus =
 type IProps = {
   data: any
   height?: string | number
+  onRefresh?: () => void
 }
 
 const Yaml = (props: IProps) => {
@@ -47,7 +49,7 @@ const Yaml = (props: IProps) => {
   const interpretEndRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   const observerRef = useRef<MutationObserver | null>(null)
-  const { data } = props
+  const { data, onRefresh } = props
   const [moduleHeight, setModuleHeight] = useState<number>(500)
   const [interpretStatus, setInterpretStatus] =
     useState<InterpretStatus>('idle')
@@ -56,6 +58,10 @@ const Yaml = (props: IProps) => {
   const abortControllerRef = useRef<AbortController | null>(null)
   const { aiOptions } = useSelector((state: any) => state.globalSlice)
   const isAIEnabled = aiOptions?.AIModel && aiOptions?.AIAuthToken
+
+  useEffect(() => {
+    onRefresh?.()
+  }, [])
 
   useEffect(() => {
     const yamlStatusJson = yaml2json(data)
@@ -294,6 +300,15 @@ const Yaml = (props: IProps) => {
                             type="text"
                             icon={<FullscreenOutlined />}
                             onClick={handle.enter}
+                          />
+                        </Tooltip>
+                      )}
+                      {!handle.active && onRefresh && (
+                        <Tooltip title={t('YAML.Refresh')}>
+                          <Button
+                            type="text"
+                            onClick={onRefresh}
+                            icon={<ReloadOutlined />}
                           />
                         </Tooltip>
                       )}

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -157,7 +157,8 @@
     "InterpretConnectionError": "Interpretation connection error",
     "FailedToStartInterpret": "Failed to start interpretation",
     "FailedToInterpret": "Failed to interpret",
-    "TabName": "YAML"
+    "TabName": "YAML",
+    "Refresh": "Refresh"
   },
   "Yesterday": "Yesterday",
   "Collapse": "Collapse",

--- a/ui/src/pages/insightDetail/cluster/index.tsx
+++ b/ui/src/pages/insightDetail/cluster/index.tsx
@@ -318,7 +318,7 @@ const ClusterDetail = () => {
       }
     }
     if (currentTab === 'YAML') {
-      return <Yaml data={yamlData || ''} />
+      return <Yaml data={yamlData || ''} onRefresh={getClusterDetail} />
     }
     if (currentTab === 'K8s') {
       return (


### PR DESCRIPTION
## What type of PR is this?

<!--
/kind feature
-->

## What this PR does / why we need it:

Add refresh button on YAML tab to allow users manually refresh YAML data in cluster management view. 

This improves user experience by providing direct control over YAML data refresh.

![Snipaste_2025-03-07_21-14-50](https://github.com/user-attachments/assets/7a1f13d1-af5c-4338-97ce-91c77d8399a5)

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #712 
